### PR TITLE
Remove bboxes saving when processing keypoints in COCO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/539>)
 
 ### Removed
-- TBD
+- Bounding boxes saving when processing keypoints in COCO
+  (<https://github.com/cvat-ai/datumaro/pull/1>)
 
 ### Fixed
 - Detection for LFW format

--- a/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/plugins/coco_format/converter.py
@@ -248,7 +248,13 @@ class _InstancesConverter(_TaskConverter):
         return [
             a
             for a in annotations
-            if a.type in {AnnotationType.bbox, AnnotationType.points, AnnotationType.polygon, AnnotationType.mask}
+            if a.type
+            in {
+                AnnotationType.bbox,
+                AnnotationType.points,
+                AnnotationType.polygon,
+                AnnotationType.mask,
+            }
         ]
 
     @classmethod

--- a/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/plugins/coco_format/converter.py
@@ -200,9 +200,10 @@ class _InstancesConverter(_TaskConverter):
     def find_instance_parts(self, group, img_width, img_height):
         boxes = [a for a in group if a.type == AnnotationType.bbox]
         polygons = [a for a in group if a.type == AnnotationType.polygon]
+        points = [a for a in group if a.type == AnnotationType.points]
         masks = [a for a in group if a.type == AnnotationType.mask]
 
-        anns = boxes + polygons + masks
+        anns = boxes + polygons + points + masks
         leader = anno_tools.find_group_leader(anns)
         bbox = anno_tools.max_bbox(anns)
         mask = None
@@ -247,7 +248,7 @@ class _InstancesConverter(_TaskConverter):
         return [
             a
             for a in annotations
-            if a.type in {AnnotationType.bbox, AnnotationType.polygon, AnnotationType.mask}
+            if a.type in {AnnotationType.bbox, AnnotationType.points, AnnotationType.polygon, AnnotationType.mask}
         ]
 
     @classmethod

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -412,7 +412,7 @@ class _CocoExtractor(SourceExtractor):
                             rle=rle, label=label_id, id=ann_id, attributes=attributes, group=group
                         )
                     )
-            else:
+            elif self._task is not CocoTask.person_keypoints:
                 bbox = self._parse_field(ann, "bbox", list)
                 if len(bbox) != 4:
                     raise InvalidAnnotationError(

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -343,7 +343,6 @@ class CocoImporterTest(TestCase):
                             group=1,
                             attributes={"is_crowd": False},
                         ),
-                        Bbox(2, 2, 3, 1, label=1, id=1, group=1, attributes={"is_crowd": False}),
                     ],
                 ),
                 DatasetItem(
@@ -441,7 +440,6 @@ class CocoImporterTest(TestCase):
                             group=1,
                             attributes={"is_crowd": False},
                         ),
-                        Bbox(2, 2, 3, 1, label=1, id=1, group=1, attributes={"is_crowd": False}),
                     ],
                 ),
             ],
@@ -483,7 +481,6 @@ class CocoImporterTest(TestCase):
                             group=1,
                             attributes={"is_crowd": False},
                         ),
-                        Bbox(2, 2, 3, 1, label=2, id=1, group=1, attributes={"is_crowd": False}),
                     ],
                 ),
             ],
@@ -1703,7 +1700,6 @@ class CocoConverterTest(TestCase):
                         Polygon([0, 0, 4, 0, 4, 4], label=3, group=1, id=1),
                         # Full instance annotations: bbox + keypoints
                         Points([1, 2, 3, 4, 2, 3], group=2, id=2),
-                        Bbox(1, 2, 2, 2, group=2, id=2),
                         # Solitary keypoints
                         Points([1, 2, 0, 2, 4, 1], label=5, id=3),
                         # Some other solitary annotations (bug #1387)
@@ -1744,7 +1740,6 @@ class CocoConverterTest(TestCase):
                             attributes={"is_crowd": False},
                         ),
                         Points([1, 2, 3, 4, 2, 3], group=2, id=2, attributes={"is_crowd": False}),
-                        Bbox(1, 2, 2, 2, group=2, id=2, attributes={"is_crowd": False}),
                         Points(
                             [1, 2, 0, 2, 4, 1],
                             label=5,
@@ -1752,7 +1747,6 @@ class CocoConverterTest(TestCase):
                             id=3,
                             attributes={"is_crowd": False},
                         ),
-                        Bbox(0, 1, 4, 1, label=5, group=3, id=3, attributes={"is_crowd": False}),
                         Points(
                             [0, 0, 1, 2, 3, 4],
                             [0, 1, 2],
@@ -1760,7 +1754,6 @@ class CocoConverterTest(TestCase):
                             id=5,
                             attributes={"is_crowd": False},
                         ),
-                        Bbox(1, 2, 2, 2, group=5, id=5, attributes={"is_crowd": False}),
                     ],
                     attributes={"id": 1},
                 ),


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/datumaro/blob/develop/CONTRIBUTING.md -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Removed bboxes saving when processing keypoints in COCO (This information is calculated from points. In CVAT, these bboxes are redundant and unnecessary annotations)

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](
  https://github.com/openvinotoolkit/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/openvinotoolkit/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
