### PR TITLE
Add format and media type to info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/706>)
 - NYU Depth Dataset V2 format (import-only)
   (<https://github.com/openvinotoolkit/datumaro/pull/712>)
+- `format` and `media type` fields in the `info` command output
+  (<https://github.com/cvat-ai/datumaro/pull/5>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YOLO format now supports almost any subset names, except `backup`, `names` and `classes`
   (instead of just `train` and `valid`). The reserved names now raise an error on exporting.
   (<https://github.com/openvinotoolkit/datumaro/pull/688>)
+- \[CLI\] Removed the `--all` flag in `datum info`, added the `--json` flag
+  (<https://github.com/cvat-ai/datumaro/pull/5>)
 
 ### Deprecated
 - `--save-images` is replaced with `--save-media` in CLI and converter API

--- a/datumaro/cli/commands/info.py
+++ b/datumaro/cli/commands/info.py
@@ -1,11 +1,16 @@
 # Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 
 import argparse
+from re import L
+from typing import Type, Union
 
+from datumaro.components.dataset import Dataset, IDataset
 from datumaro.components.errors import DatasetMergeError, MissingObjectError, ProjectNotFoundError
 from datumaro.components.extractor import AnnotationType
+from datumaro.components.media import Image, MediaElement, MultiframeImage, PointCloud, Video
 from datumaro.util.scope import scope_add, scoped
 
 from ..util import MultilineFormatter
@@ -93,7 +98,23 @@ def info_command(args):
     except MissingObjectError as e:
         dataset_problem = str(e)
 
-    def print_dataset_info(dataset, indent=""):
+    def render_media_type(t: Type[MediaElement]) -> str:
+        mapping = {
+            Image: "image",
+            Video: "video",
+            PointCloud: "point_cloud",
+            MultiframeImage: "multiframe_image",
+        }
+        for k, v in mapping.items():
+            if issubclass(t, k):
+                return v
+        return "unknown"
+
+    def print_dataset_info(dataset: Union[Dataset, IDataset], indent: str = ""):
+        if isinstance(dataset, Dataset):
+            print("%sformat:" % indent, dataset.format or "unknown")
+
+        print("%smedia type:" % indent, render_media_type(dataset.media_type()))
         print("%slength:" % indent, len(dataset))
 
         categories = dataset.categories()

--- a/datumaro/cli/commands/info.py
+++ b/datumaro/cli/commands/info.py
@@ -7,7 +7,7 @@ import argparse
 from typing import Any, Dict, Type, cast
 
 from datumaro.components.annotation import LabelCategories
-from datumaro.components.dataset import Dataset, IDataset
+from datumaro.components.dataset import Dataset
 from datumaro.components.errors import DatasetMergeError, MissingObjectError, ProjectNotFoundError
 from datumaro.components.extractor import AnnotationType
 from datumaro.components.media import Image, MediaElement, MultiframeImage, PointCloud, Video

--- a/datumaro/cli/commands/info.py
+++ b/datumaro/cli/commands/info.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
-from re import L
 from typing import Type, Union
 
 from datumaro.components.dataset import Dataset, IDataset

--- a/datumaro/cli/commands/info.py
+++ b/datumaro/cli/commands/info.py
@@ -4,12 +4,14 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
-from typing import Type, Union
+from typing import Any, Dict, Type, cast
 
+from datumaro.components.annotation import LabelCategories
 from datumaro.components.dataset import Dataset, IDataset
 from datumaro.components.errors import DatasetMergeError, MissingObjectError, ProjectNotFoundError
 from datumaro.components.extractor import AnnotationType
 from datumaro.components.media import Image, MediaElement, MultiframeImage, PointCloud, Video
+from datumaro.util import dump_json
 from datumaro.util.scope import scope_add, scoped
 
 from ..util import MultilineFormatter
@@ -43,8 +45,8 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
         - Print dataset info for a path and a format name:|n
         |s|s%(prog)s path/to/dataset:voc|n
         |n
-        - Print dataset info for a source from a past revision:|n
-        |s|s%(prog)s HEAD~2:source-2
+        - Print dataset info for a source from a past revision in JSON format:|n
+        |s|s%(prog)s --json HEAD~2:source-2
         """,
         formatter_class=MultilineFormatter,
     )
@@ -52,7 +54,7 @@ def build_parser(parser_ctor=argparse.ArgumentParser):
     parser.add_argument(
         "target", nargs="?", default="project", metavar="revpath", help="Target dataset revpath"
     )
-    parser.add_argument("--all", action="store_true", help="Print all information")
+    parser.add_argument("--json", action="store_true", help="Print output data in JSON format")
     parser.add_argument(
         "-p",
         "--project",
@@ -109,38 +111,72 @@ def info_command(args):
                 return v
         return "unknown"
 
-    def print_dataset_info(dataset: Union[Dataset, IDataset], indent: str = ""):
-        if isinstance(dataset, Dataset):
-            print("%sformat:" % indent, dataset.format or "unknown")
+    def render_dataset_info(dataset: Dataset) -> Dict[str, Any]:
+        result = {}
 
-        print("%smedia type:" % indent, render_media_type(dataset.media_type()))
-        print("%slength:" % indent, len(dataset))
+        result["format"] = dataset.format or "unknown"
+        result["media type"] = render_media_type(dataset.media_type())
+        result["length"] = len(dataset)
 
         categories = dataset.categories()
-        print("%scategories:" % indent, ", ".join(c.name for c in categories))
+        result["categories"] = {}
 
-        for cat_type, cat in categories.items():
-            print("%s  %s:" % (indent, cat_type.name))
-            if cat_type == AnnotationType.label:
-                print("%s    count:" % indent, len(cat.items))
+        if AnnotationType.label in categories:
+            labels_info = cast(LabelCategories, categories[AnnotationType.label])
+            result["categories"]["count"] = len(labels_info)
+            result["categories"]["labels"] = [
+                {
+                    "id": idx,
+                    "name": label.name,
+                    "parent": label.parent,
+                    "attributes": list(label.attributes),
+                }
+                for idx, label in enumerate(labels_info)
+            ]
+        else:
+            result["categories"]["count"] = 0
+            result["categories"]["labels"] = []
 
-                count_threshold = 10
-                if args.all:
-                    count_threshold = len(cat.items)
-                labels = ", ".join(c.name for c in cat.items[:count_threshold])
-                if count_threshold < len(cat.items):
-                    labels += " (and %s more)" % (len(cat.items) - count_threshold)
-                print("%s    labels:" % indent, labels)
+        result["subsets"] = []
+        for subset_name, subset in dataset.subsets().items():
+            result["subsets"].append({"name": subset_name, "length": len(subset)})
+
+        return result
+
+    DEFAULT_INDENT = 4 * " "
+    LIST_COUNT_THRESHOLD = 10
+
+    def print_dataset_info(data: Dict[str, Any], *, indent: str = ""):
+        def _print_basic_type(key: str, data: Dict[str, Any], *, indent: str = indent):
+            print(f"{indent}{key}:", data[key])
+
+        if "format" in data:
+            _print_basic_type("format", data)
+
+        _print_basic_type("media type", data)
+        _print_basic_type("length", data)
+
+        print(indent + "categories:")
+        count_threshold = LIST_COUNT_THRESHOLD
+        labels = data["categories"]["labels"]
+        labels_repr = ", ".join(label["name"] for label in labels[:count_threshold])
+        if count_threshold < len(labels):
+            labels_repr += " (and %s more)" % (len(labels) - count_threshold)
+        print(DEFAULT_INDENT + indent + "labels:", labels_repr)
+
+        subsets = data["subsets"]
+        if subsets:
+            print("subsets:")
+        for subset_info in subsets:
+            print(DEFAULT_INDENT + indent + subset_info["name"] + ":")
+            _print_basic_type("length", subset_info, indent=2 * DEFAULT_INDENT + indent)
 
     if dataset is not None:
-        print_dataset_info(dataset)
-
-        subsets = dataset.subsets()
-        print("subsets:", ", ".join(subsets))
-        for subset_name in subsets:
-            subset = dataset.get_subset(subset_name)
-            print("  '%s':" % subset_name)
-            print_dataset_info(subset, indent="    ")
+        output_data = render_dataset_info(dataset)
+        if args.json:
+            print(dump_json(output_data, indent=True, append_newline=True).decode())
+        else:
+            print_dataset_info(output_data)
     else:
         print("Dataset info is not available: ", dataset_problem)
 

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -92,6 +92,12 @@ class Categories:
 
 @attrs(slots=True, order=False)
 class LabelCategories(Categories):
+    """
+    The list of labels defined for the dataset. Other categories provide additional info
+    for these basic declarations. Indices in other category types must reference labels
+    defined here. Supposed to be always defined for a dataset.
+    """
+
     @attrs(slots=True, order=False)
     class Category:
         name: str = field(converter=str, validator=not_empty)

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -12,7 +12,7 @@ import unittest.mock
 import warnings
 from enum import Enum, auto
 from glob import glob
-from typing import Collection, Optional, Union
+from typing import Any, Collection, Optional, Union
 
 from typing_extensions import Literal
 
@@ -307,10 +307,15 @@ def compare_dirs(test, expected: str, actual: str):
             test.assertEqual(a_file.read(), b_file.read(), rel_path)
 
 
-def run_datum(test, *args, expected_code=0):
+def run_datum(test: Union[unittest.TestCase, Any], *args, expected_code: int = 0):
     from datumaro.cli.__main__ import main
 
-    test.assertEqual(expected_code, main(args), str(args))
+    status = main(args)
+
+    if isinstance(test, unittest.TestCase):
+        test.assertEqual(expected_code, status, str(args))
+    else:
+        assert status == expected_code
 
 
 @contextlib.contextmanager

--- a/site/content/en/docs/user-manual/command-reference/info.md
+++ b/site/content/en/docs/user-manual/command-reference/info.md
@@ -10,13 +10,13 @@ categories and subsets.
 Usage:
 
 ``` bash
-datum info [-h] [--all] [-p PROJECT_DIR] [revpath]
+datum info [-h] [--json] [-p PROJECT_DIR] [revpath]
 ```
 
 Parameters:
 - `<target>` (string) - Target [dataset revpath](/docs/user-manual/how_to_use_datumaro/#revpath).
   By default, prints info about the joined `project` dataset.
-- `--all` - Print all the information: do not fold long lists of labels etc.
+- `--json` - Print output data in JSON format
 - `-p, --project` (string) - Directory of the project to operate on
   (default: current directory).
 - `-h, --help` - Print the help message and exit.
@@ -33,16 +33,45 @@ Examples:
 Sample output:
 
 ```
-length: 5000
-categories: label
-  label:
-    count: 80
-    labels: person, bicycle, car, motorcycle (and 76 more)
-subsets: minival2014
-  'minival2014':
-    length: 5000
-    categories: label
-      label:
-        count: 80
-        labels: person, bicycle, car, motorcycle (and 76 more)
+format: voc
+media type: image
+length: 5
+categories:
+    labels: background, aeroplane, bicycle, bird, boat, bottle, bus, car, cat, chair (and 12 more)
+subsets:
+    trainval:
+        length: 5
 ```
+
+JSON output format:
+
+<details>
+
+```json
+{
+  "format": string,
+  "media type": string,
+  "length": integer,
+  "categories": {
+    "count": integer,
+    "labels": [
+      {
+        "id": integer,
+        "name": string,
+        "parent": string,
+        "attributes": [ string, ... ]
+      },
+      ...
+    ]
+  },
+  "subsets": [
+    {
+      "name": string,
+      "length": integer
+    },
+    ...
+  ]
+}
+```
+
+</details>

--- a/tests/cli/test_info.py
+++ b/tests/cli/test_info.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from datumaro.util import parse_json
 from datumaro.util.test_utils import run_datum
 
 from ..requirements import Requirements, mark_requirement
@@ -51,3 +52,12 @@ class InfoTest:
         assert "format: coco" in stdout
         assert "media type: image" in stdout
         assert "subsets" in stdout
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_print_info_for_dataset_in_json_format(self):
+        stdout = self.run("info", "--json", DUMMY_DATASET_DIR)
+
+        result = parse_json(stdout)
+        assert result["format"] == "coco"
+        assert result["media type"] == "image"
+        assert len(result["subsets"]) == 2

--- a/tests/cli/test_info.py
+++ b/tests/cli/test_info.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2022 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import io
+import os.path as osp
+from pathlib import Path
+
+import pytest
+
+from datumaro.util.test_utils import run_datum
+
+from ..requirements import Requirements, mark_requirement
+
+DUMMY_DATASET_DIR = osp.join(
+    __file__[: __file__.rfind(osp.join("tests", ""))],
+    "tests",
+    "assets",
+    "coco_dataset",
+    "coco_instances",
+)
+
+
+class InfoTest:
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        fxt_stdout: io.StringIO,
+        tmp_path: Path,
+    ):
+        self.tmp_path = tmp_path
+        self.stdout = fxt_stdout
+
+        yield
+
+        self.tmp_path = None
+
+    def run(self, cmd: str, *args: str, expected_code: int = 0) -> str:
+        run_datum(
+            self,
+            cmd,
+            *args,
+            expected_code=expected_code,
+        )
+        return self.stdout.getvalue()
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_print_info_for_dataset(self):
+        stdout = self.run("info", DUMMY_DATASET_DIR)
+
+        assert "format: coco" in stdout
+        assert "media type: image" in stdout
+        assert "subsets" in stdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
+
+from .fixtures import *
 
 
 def pytest_configure(config):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2022 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+
+@pytest.fixture
+def fxt_stdout():
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        yield stream


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Added `format` and `media type` fields into the `info` command
- Added the `--json` option to print output as JSON
- Removed the `--all` option

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
