### PR TITLE
Add storing labels with the same name but with a different parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/712>)
 - Skeleton annotation type
   (<https://github.com/cvat-ai/datumaro/pull/6>)
+- Storing labels with the same name but with a different parent
+  (<https://github.com/cvat-ai/datumaro/pull/8>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -151,11 +151,12 @@ class LabelCategories(Categories):
         self, name: str, parent: Optional[str] = "", attributes: Optional[Set[str]] = None
     ) -> int:
         assert name
-        assert parent + name not in self._indices
+        key = (parent or "") + name
+        assert key not in self._indices
 
         index = len(self.items)
         self.items.append(self.Category(name, parent, attributes))
-        self._indices[parent + name] = index
+        self._indices[key] = index
         return index
 
     def find(self, name: str, parent: str = "") -> Tuple[Optional[int], Optional[Category]]:

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -151,7 +151,7 @@ class LabelCategories(Categories):
         self, name: str, parent: Optional[str] = None, attributes: Optional[Set[str]] = None
     ) -> int:
         assert name
-        assert (parent if parent else "") + name not in self._indices, name
+        assert (parent if parent else "") + name not in self._indices
 
         index = len(self.items)
         self.items.append(self.Category(name, parent, attributes))

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -143,23 +143,23 @@ class LabelCategories(Categories):
     def _reindex(self):
         indices = {}
         for index, item in enumerate(self.items):
-            assert item.name not in self._indices
-            indices[item.name] = index
+            assert (item.parent + item.name) not in self._indices
+            indices[item.parent + item.name] = index
         self._indices = indices
 
     def add(
         self, name: str, parent: Optional[str] = None, attributes: Optional[Set[str]] = None
     ) -> int:
         assert name
-        assert name not in self._indices, name
+        assert (parent if parent else "") + name not in self._indices, name
 
         index = len(self.items)
         self.items.append(self.Category(name, parent, attributes))
-        self._indices[name] = index
+        self._indices[(parent if parent else "") + name] = index
         return index
 
-    def find(self, name: str) -> Tuple[Optional[int], Optional[Category]]:
-        index = self._indices.get(name)
+    def find(self, name: str, parent: str = "") -> Tuple[Optional[int], Optional[Category]]:
+        index = self._indices.get(parent + name)
         if index is not None:
             return index, self.items[index]
         return index, None

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -148,14 +148,14 @@ class LabelCategories(Categories):
         self._indices = indices
 
     def add(
-        self, name: str, parent: Optional[str] = None, attributes: Optional[Set[str]] = None
+        self, name: str, parent: Optional[str] = "", attributes: Optional[Set[str]] = None
     ) -> int:
         assert name
-        assert (parent if parent else "") + name not in self._indices
+        assert parent + name not in self._indices
 
         index = len(self.items)
         self.items.append(self.Category(name, parent, attributes))
-        self._indices[(parent if parent else "") + name] = index
+        self._indices[parent + name] = index
         return index
 
     def find(self, name: str, parent: str = "") -> Tuple[Optional[int], Optional[Category]]:

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -559,7 +559,7 @@ class IntersectMerge(MergingStrategy):
                 continue
 
             for src_label in src_cat.items:
-                dst_label = dst_cat.find(src_label.name)[1]
+                dst_label = dst_cat.find(src_label.name, src_label.parent)[1]
                 if dst_label is not None:
                     if dst_label != src_label:
                         if (
@@ -593,7 +593,8 @@ class IntersectMerge(MergingStrategy):
 
             for src_label_id, src_cat in src_point_cat.items.items():
                 src_label = src_label_cat.items[src_label_id].name
-                dst_label_id = label_cat.find(src_label)[0]
+                src_parent_label = src_label_cat.items[src_label_id].parent
+                dst_label_id = label_cat.find(src_label, src_parent_label)[0]
                 dst_cat = dst_point_cat.items.get(dst_label_id)
                 if dst_cat is not None:
                     if dst_cat != src_cat:
@@ -623,7 +624,8 @@ class IntersectMerge(MergingStrategy):
 
             for src_label_id, src_cat in src_mask_cat.colormap.items():
                 src_label = src_label_cat.items[src_label_id].name
-                dst_label_id = label_cat.find(src_label)[0]
+                src_parent_label = src_label_cat.items[src_label_id].parent
+                dst_label_id = label_cat.find(src_label, src_parent_label)[0]
                 dst_cat = dst_mask_cat.colormap.get(dst_label_id)
                 if dst_cat is not None:
                     if dst_cat != src_cat:
@@ -865,8 +867,10 @@ class IntersectMerge(MergingStrategy):
             return None
         return self._categories[AnnotationType.label].items[label_id].name
 
-    def _get_label_id(self, label):
-        return self._categories[AnnotationType.label].find(label)[0]
+    def _get_label_id(self, label, parent=""):
+        if label is not None:
+            return self._categories[AnnotationType.label].find(label, parent)[0]
+        return None
 
     def _get_src_label_name(self, ann, label_id):
         if label_id is None:

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -341,6 +341,7 @@ class _CocoExtractor(SourceExtractor):
                         "which is not divisible by 3. Expected (x, y, visibility) triplets."
                     )
 
+                label_cat = self.categories()[AnnotationType.label]
                 points = []
                 sublabels = []
                 if label_id is not None:
@@ -349,7 +350,7 @@ class _CocoExtractor(SourceExtractor):
                 for x, y, v in take_by(keypoints, 3):
                     sublabel = None
                     if i < len(sublabels):
-                        sublabel = self.categories()[AnnotationType.label].find(sublabels[i])[0]
+                        sublabel = label_cat.find(label_cat.items[label_id].name + sublabels[i])[0]
                     points.append(Points([x, y], [v], label=sublabel))
                     i += 1
 

--- a/datumaro/plugins/cvat_format/extractor.py
+++ b/datumaro/plugins/cvat_format/extractor.py
@@ -397,7 +397,7 @@ class CvatExtractor(SourceExtractor):
         return categories, frame_size, attribute_types
 
     @classmethod
-    def _parse_shape_ann(cls, ann, categories):
+    def _parse_shape_ann(cls, ann, categories, parent_label=""):
         ann_id = ann.get("id", 0)
         ann_type = ann["type"]
 
@@ -414,7 +414,7 @@ class CvatExtractor(SourceExtractor):
         group = ann.get("group")
 
         label = ann.get("label")
-        label_id = categories[AnnotationType.label].find(label)[0]
+        label_id = categories[AnnotationType.label].find(label, parent_label)[0]
 
         z_order = ann.get("z_order", 0)
         points = ann.get("points", [])
@@ -467,7 +467,7 @@ class CvatExtractor(SourceExtractor):
         elif ann_type == "skeleton":
             elements = []
             for element in ann.get("elements", []):
-                elements.append(cls._parse_shape_ann(element, categories))
+                elements.append(cls._parse_shape_ann(element, categories, label))
 
             return Skeleton(
                 elements,

--- a/datumaro/plugins/mapillary_vistas_format/extractor.py
+++ b/datumaro/plugins/mapillary_vistas_format/extractor.py
@@ -27,6 +27,7 @@ from .format import (
     MapillaryVistasLabelMaps,
     MapillaryVistasPath,
     MapillaryVistasTask,
+    get_parent_label,
     make_mapillary_instance_categories,
     parse_config_file,
 )
@@ -241,9 +242,10 @@ class _MapillaryVistasExtractor(SourceExtractor):
             annotations = []
             for polygon in polygons:
                 label = polygon["label"]
-                label_id = self._categories[AnnotationType.label].find(label)[0]
+                parent = get_parent_label(label)
+                label_id = self._categories[AnnotationType.label].find(label, parent)[0]
                 if label_id is None:
-                    label_id = self._categories[AnnotationType.label].add(label)
+                    label_id = self._categories[AnnotationType.label].add(label, parent)
 
                 points = [coord for point in polygon["polygon"] for coord in point]
                 annotations.append(Polygon(label=label_id, points=points))

--- a/datumaro/plugins/mapillary_vistas_format/extractor.py
+++ b/datumaro/plugins/mapillary_vistas_format/extractor.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
+
 import glob
 import logging as log
 import os

--- a/datumaro/plugins/mapillary_vistas_format/format.py
+++ b/datumaro/plugins/mapillary_vistas_format/format.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/plugins/mapillary_vistas_format/format.py
+++ b/datumaro/plugins/mapillary_vistas_format/format.py
@@ -17,17 +17,22 @@ def parse_config_file(config_path):
         label_map[label["name"]] = tuple(map(int, label["color"]))
     return label_map
 
+def get_parent_label(label):
+    parent = label.split("--")[0]
+    if parent == label:
+        parent = ""
+    return parent
 
 def make_mapillary_instance_categories(label_map):
     label_cat = LabelCategories()
     for label, _ in label_map.items():
-        label_cat.add(label)
+        label_cat.add(label, get_parent_label(label))
 
     has_colors = any([len(color) == 3 for color in label_map.values()])
     if not has_colors:
         colormap = generate_colormap(len(label_map))
     else:
-        colormap = {label_cat.find(label)[0]: color for label, color in label_map.items()}
+        colormap = {label_cat.find(label, get_parent_label(label))[0]: color for label, color in label_map.items()}
 
     mask_cat = MaskCategories(colormap)
     mask_cat.inverse_colormap  # pylint: disable=pointless-statement

--- a/datumaro/plugins/mapillary_vistas_format/format.py
+++ b/datumaro/plugins/mapillary_vistas_format/format.py
@@ -17,11 +17,13 @@ def parse_config_file(config_path):
         label_map[label["name"]] = tuple(map(int, label["color"]))
     return label_map
 
+
 def get_parent_label(label):
     parent = label.split("--")[0]
     if parent == label:
         parent = ""
     return parent
+
 
 def make_mapillary_instance_categories(label_map):
     label_cat = LabelCategories()
@@ -32,7 +34,10 @@ def make_mapillary_instance_categories(label_map):
     if not has_colors:
         colormap = generate_colormap(len(label_map))
     else:
-        colormap = {label_cat.find(label, get_parent_label(label))[0]: color for label, color in label_map.items()}
+        colormap = {
+            label_cat.find(label, get_parent_label(label))[0]: color
+            for label, color in label_map.items()
+        }
 
     mask_cat = MaskCategories(colormap)
     mask_cat.inverse_colormap  # pylint: disable=pointless-statement

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -747,7 +747,11 @@ class ProjectLabels(ItemTransform):
         )
         return parser
 
-    def __init__(self, extractor: IExtractor, dst_labels: Union[Iterable[Union[str, Tuple[str, str]]], LabelCategories]):
+    def __init__(
+        self,
+        extractor: IExtractor,
+        dst_labels: Union[Iterable[Union[str, Tuple[str, str]]], LabelCategories],
+    ):
         super().__init__(extractor)
 
         self._categories = {}

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -747,7 +747,7 @@ class ProjectLabels(ItemTransform):
         )
         return parser
 
-    def __init__(self, extractor: IExtractor, dst_labels: Union[Iterable[str], LabelCategories]):
+    def __init__(self, extractor: IExtractor, dst_labels: Union[Iterable[Union[str, Tuple[str, str]]], LabelCategories]):
         super().__init__(extractor)
 
         self._categories = {}
@@ -765,14 +765,17 @@ class ProjectLabels(ItemTransform):
                 dst_label_cat = LabelCategories(attributes=deepcopy(src_label_cat.attributes))
 
                 for dst_label in dst_labels:
-                    assert isinstance(dst_label, str)
-                    src_label = src_label_cat.find(dst_label)[1]
+                    assert isinstance(dst_label, str) or isinstance(dst_label, tuple)
+                    dst_parent = ""
+                    if isinstance(dst_label, tuple):
+                        dst_label, dst_parent = dst_label
+                    src_label = src_label_cat.find(dst_label, dst_parent)[1]
                     if src_label is not None:
                         dst_label_cat.add(
                             dst_label, src_label.parent, deepcopy(src_label.attributes)
                         )
                     else:
-                        dst_label_cat.add(dst_label)
+                        dst_label_cat.add(dst_label, dst_parent)
             else:
                 dst_label_cat = LabelCategories.from_iterable(dst_labels)
 
@@ -824,7 +827,7 @@ class ProjectLabels(ItemTransform):
 
     def _make_label_id_map(self, src_label_cat, dst_label_cat):
         id_mapping = {
-            src_id: dst_label_cat.find(src_label_cat[src_id].name)[0]
+            src_id: dst_label_cat.find(src_label_cat[src_id].name, src_label_cat[src_id].parent)[0]
             for src_id in range(len(src_label_cat or ()))
         }
         self._map_id = lambda src_id: id_mapping.get(src_id, None)

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -82,10 +82,7 @@ class VggFace2Extractor(Extractor):
             for line in lines:
                 objects = line.split()
                 label = objects[0]
-                class_name = None
-                if 1 < len(objects):
-                    class_name = objects[1]
-                label_cat.add(label, parent=class_name)
+                label_cat.add(label)
         else:
             for subset in self._subsets:
                 subset_path = osp.join(self._dataset_dir, subset)

--- a/datumaro/plugins/vgg_face2_format.py
+++ b/datumaro/plugins/vgg_face2_format.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/test_mapillary_vistas_format.py
+++ b/tests/test_mapillary_vistas_format.py
@@ -32,7 +32,11 @@ class MapillaryVistasImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_v1_2(self):
         label_cat = LabelCategories.from_iterable(
-            ["animal--bird", "construction--barrier--curb", "human--person"]
+            [
+                ("animal--bird", "animal"),
+                ("construction--barrier--curb", "construction"),
+                ("human--person", "human"),
+            ]
         )
         mask_cat = MaskCategories({0: (10, 50, 90), 1: (20, 30, 80), 2: (30, 70, 40)})
 
@@ -130,7 +134,11 @@ class MapillaryVistasImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_v2_0_instances(self):
         label_cat = LabelCategories.from_iterable(
-            ["animal--bird", "construction--barrier--separator", "object--vehicle--bicycle"]
+            [
+                ("animal--bird", "animal"),
+                ("construction--barrier--separator", "construction"),
+                ("object--vehicle--bicycle", "object"),
+            ]
         )
 
         mask_cat = MaskCategories({0: (165, 42, 42), 1: (128, 128, 128), 2: (119, 11, 32)})
@@ -508,7 +516,11 @@ class MapillaryVistasImporterTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_import_with_meta_file(self):
         label_cat = LabelCategories.from_iterable(
-            ["animal--bird", "construction--barrier--curb", "human--person"]
+            [
+                ("animal--bird", "animal"),
+                ("construction--barrier--curb", "construction"),
+                ("human--person", "human"),
+            ]
         )
         mask_cat = MaskCategories({0: (10, 50, 90), 1: (20, 30, 80), 2: (30, 70, 40)})
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -700,7 +700,6 @@ class TransformsTest(TestCase):
                     [
                         ("c", "a"),  # must keep parent
                         "a",
-                        "d",  # must drop parent because it was removed
                     ]
                 ),
                 AnnotationType.points: PointsCategories.from_iterable([(0, ["c"]), (1, ["a"])]),
@@ -709,7 +708,7 @@ class TransformsTest(TestCase):
                         i: v
                         for i, v in {
                             {2: 0, 0: 1, 3: 2}.get(k): v
-                            for k, v in mask_tools.generate_colormap(4).items()
+                            for k, v in mask_tools.generate_colormap(3).items()
                         }.items()
                         if i is not None
                     }
@@ -717,7 +716,7 @@ class TransformsTest(TestCase):
             },
         )
 
-        actual = transforms.ProjectLabels(source, dst_labels=["c", "a", "d"])
+        actual = transforms.ProjectLabels(source, dst_labels=[("c", "a"), "a"])
 
         compare_datasets(self, expected, actual)
 

--- a/tests/test_vgg_face2_format.py
+++ b/tests/test_vgg_face2_format.py
@@ -69,7 +69,7 @@ class VggFace2FormatTest(TestCase):
             ],
             categories={
                 AnnotationType.label: LabelCategories.from_iterable(
-                    [("label_%s" % i, "class_%s" % i) for i in range(5)]
+                    [f"label_{i}" for i in range(5)]
                 ),
             },
         )
@@ -328,7 +328,7 @@ class VggFace2ImporterTest(TestCase):
             ],
             categories={
                 AnnotationType.label: LabelCategories.from_iterable(
-                    [("n000001", "Karl"), ("n000002", "Jay"), ("n000003", "Pol")]
+                    ["n000001", "n000002", "n000003"]
                 ),
             },
         )
@@ -353,7 +353,7 @@ class VggFace2ImporterTest(TestCase):
             ],
             categories={
                 AnnotationType.label: LabelCategories.from_iterable(
-                    [("n000001", "Karl"), ("n000002", "Jay"), ("n000003", "Pol")]
+                    ["n000001", "n000002", "n000003"]
                 ),
             },
         )


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Added the ability to store labels with the same name
- Some fixes for formats

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
