### PR TITLE
COCO: save skeleton points in the correct order if they are labelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NYU Depth Dataset V2 format (import-only)
   (<https://github.com/openvinotoolkit/datumaro/pull/712>)
 - Skeleton annotation type
-  (<https://github.com/cvat-ai/datumaro/pull/6>)
+  (<https://github.com/cvat-ai/datumaro/pull/6>,
+  <https://github.com/cvat-ai/datumaro/pull/14>)
 - Storing labels with the same name but with a different parent
   (<https://github.com/cvat-ai/datumaro/pull/8>)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
The COCO format does not support storing points out of order; they must be stored in the same order as they are listed in the skeleton definition. If the points in the dataset are not labelled, we can only assume they are already in the right order; but if they are, we can use the labels to rearrange them into the correct order before saving.

If we don't do this, and the dataset has the points in an arbitrary order (which can happen when it is converted from CVAT), then the points will be written in that arbitrary order, making the original mapping of point-to-label no longer recoverable.

See also opencv/cvat#5048.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
