### PR TITLE
COCO: when saving, don't drop standalone skeletons that have group IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/712>)
 - Skeleton annotation type
   (<https://github.com/cvat-ai/datumaro/pull/6>,
-  <https://github.com/cvat-ai/datumaro/pull/14>)
+  <https://github.com/cvat-ai/datumaro/pull/14>,
+  <https://github.com/cvat-ai/datumaro/pull/15>)
 - Storing labels with the same name but with a different parent
   (<https://github.com/cvat-ai/datumaro/pull/8>)
 

--- a/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/plugins/coco_format/converter.py
@@ -397,6 +397,7 @@ class _KeypointsConverter(_InstancesConverter):
         solitary_points = []
 
         for g_id, group in groupby(annotations, lambda a: a.group):
+            group = list(group)  # we'll need to iterate over these multiple times
             if not g_id or g_id and not cls.find_instance_anns(group):
                 group = [a for a in group if a.type == AnnotationType.skeleton]
                 solitary_points.extend(group)

--- a/tests/test_coco_format.py
+++ b/tests/test_coco_format.py
@@ -1717,13 +1717,17 @@ class CocoConverterTest(TestCase):
                         # Full instance annotations: bbox + keypoints
                         Skeleton([Points([1, 2]), Points([3, 4]), Points([2, 3])], group=2, id=2),
                         Bbox(1, 2, 2, 2, group=2, id=2),
-                        # Solitary keypoints
+                        # Solitary keypoints without group
                         Skeleton([Points([1, 2]), Points([0, 2]), Points([4, 1])], label=5, id=3),
+                        # Solitary keypoints with group
+                        Skeleton(
+                            [Points([1, 2]), Points([2, 1]), Points([3, 4])], label=4, group=3, id=4
+                        ),
                         # Some other solitary annotations (bug #1387)
-                        Polygon([0, 0, 4, 0, 4, 4], label=3, id=4),
+                        Polygon([0, 0, 4, 0, 4, 4], label=3, id=5),
                         # Solitary keypoints with no label
                         Skeleton(
-                            [Points([0, 0], [0]), Points([1, 2], [1]), Points([3, 4], [2])], id=5
+                            [Points([0, 0], [0]), Points([1, 2], [1]), Points([3, 4], [2])], id=6
                         ),
                     ],
                 ),
@@ -1773,12 +1777,20 @@ class CocoConverterTest(TestCase):
                         ),
                         Bbox(0, 1, 4, 1, label=5, group=3, id=3, attributes={"is_crowd": False}),
                         Skeleton(
-                            [Points([0, 0], [0]), Points([1, 2], [1]), Points([3, 4], [2])],
-                            group=5,
-                            id=5,
+                            [Points([1, 2]), Points([2, 1]), Points([3, 4])],
+                            label=4,
+                            group=4,
+                            id=4,
                             attributes={"is_crowd": False},
                         ),
-                        Bbox(1, 2, 2, 2, group=5, id=5, attributes={"is_crowd": False}),
+                        Bbox(1, 1, 2, 3, label=4, group=4, id=4, attributes={"is_crowd": False}),
+                        Skeleton(
+                            [Points([0, 0], [0]), Points([1, 2], [1]), Points([3, 4], [2])],
+                            group=6,
+                            id=6,
+                            attributes={"is_crowd": False},
+                        ),
+                        Bbox(1, 2, 2, 2, group=6, id=6, attributes={"is_crowd": False}),
                     ],
                     attributes={"id": 1},
                 ),


### PR DESCRIPTION

<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
Previously, the `find_instance_anns` calls would exhaust the `group` iterator, thus even if the condition was true, the following code would find no skeletons.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
