### PR TITLE
Change item id in MOT format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - \[CLI\] Removed the `--all` flag in `datum info`, added the `--json` flag,
   added `format` and `media type` fields in the `info` command output
   (<https://github.com/cvat-ai/datumaro/pull/5>)
+- item id in MOT format
+  (<https://github.com/cvat-ai/datumaro/pull/17>)
 
 ### Deprecated
 - `--save-images` is replaced with `--save-media` in CLI and converter API

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -131,7 +131,7 @@ class MotSeqExtractor(SourceExtractor):
         if self._seq_info:
             for frame_id in range(1, self._seq_info["seqlength"] + 1):  # base-1 frame ids
                 items[frame_id] = DatasetItem(
-                    id="%06d%s" % (frame_id, self._seq_info["imext"]),
+                    id=frame_id,
                     subset=self._subset,
                     media=Image(
                         path=osp.join(
@@ -151,10 +151,10 @@ class MotSeqExtractor(SourceExtractor):
             # - all extra fields go to a separate field
             # - all unmet fields have None values
             for row in csv.DictReader(csv_file, fieldnames=MotPath.FIELDS):
-                frame_id = row["frame_id"]
+                frame_id = int(row["frame_id"])
                 item = items.get(frame_id)
                 if item is None:
-                    frame_id = "%06d" % int(frame_id)
+                    frame_id = "%06d" % frame_id
                     item = items.get(frame_id)
                 if item is None:
                     frame_id = row["frame_id"]

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -131,8 +131,8 @@ class MotSeqExtractor(SourceExtractor):
 
         if self._seq_info:
             for frame_id in range(1, self._seq_info["seqlength"] + 1):  # base-1 frame ids
-                items[frame_id] = DatasetItem(
-                    id=frame_id,
+                items[str(frame_id)] = DatasetItem(
+                    id=str(frame_id),
                     subset=self._subset,
                     media=Image(
                         path=osp.join(
@@ -152,10 +152,10 @@ class MotSeqExtractor(SourceExtractor):
             # - all extra fields go to a separate field
             # - all unmet fields have None values
             for row in csv.DictReader(csv_file, fieldnames=MotPath.FIELDS):
-                frame_id = int(row["frame_id"])
+                frame_id = row["frame_id"]
                 item = items.get(frame_id)
                 if item is None:
-                    frame_id = "%06d" % frame_id
+                    frame_id = "%06d" % int(frame_id)
                     item = items.get(frame_id)
                 if item is None:
                     frame_id = row["frame_id"]

--- a/datumaro/plugins/mot_format.py
+++ b/datumaro/plugins/mot_format.py
@@ -131,7 +131,7 @@ class MotSeqExtractor(SourceExtractor):
         if self._seq_info:
             for frame_id in range(1, self._seq_info["seqlength"] + 1):  # base-1 frame ids
                 items[frame_id] = DatasetItem(
-                    id=frame_id,
+                    id="%06d%s" % (frame_id, self._seq_info["imext"]),
                     subset=self._subset,
                     media=Image(
                         path=osp.join(
@@ -142,7 +142,7 @@ class MotSeqExtractor(SourceExtractor):
                 )
         elif osp.isdir(self._image_dir):
             for p in find_images(self._image_dir):
-                frame_id = int(osp.splitext(osp.relpath(p, self._image_dir))[0])
+                frame_id = osp.splitext(osp.relpath(p, self._image_dir))[0]
                 items[frame_id] = DatasetItem(id=frame_id, subset=self._subset, media=Image(path=p))
 
         with open(path, newline="", encoding="utf-8") as csv_file:
@@ -151,9 +151,13 @@ class MotSeqExtractor(SourceExtractor):
             # - all extra fields go to a separate field
             # - all unmet fields have None values
             for row in csv.DictReader(csv_file, fieldnames=MotPath.FIELDS):
-                frame_id = int(row["frame_id"])
+                frame_id = row["frame_id"]
                 item = items.get(frame_id)
                 if item is None:
+                    frame_id = "%06d" % int(frame_id)
+                    item = items.get(frame_id)
+                if item is None:
+                    frame_id = row["frame_id"]
                     item = DatasetItem(id=frame_id, subset=self._subset)
                 annotations = item.annotations
 
@@ -278,7 +282,7 @@ class MotSeqGtConverter(Converter):
 
                 if self._save_media:
                     if item.media and item.media.has_data:
-                        self._save_image(item, subdir=image_dir, name="%06d" % frame_id)
+                        self._save_image(item, subdir=image_dir, name=item.id)
                     else:
                         log.debug("Item '%s' has no image", item.id)
 

--- a/tests/cli/test_voc_format.py
+++ b/tests/cli/test_voc_format.py
@@ -257,7 +257,11 @@ class VocIntegrationScenarios(TestCase):
         )
 
         mot_dir = osp.join(
-            __file__[: __file__.rfind(osp.join("tests", ""))], "tests", "assets", "mot_dataset", "mot_seq"
+            __file__[: __file__.rfind(osp.join("tests", ""))],
+            "tests",
+            "assets",
+            "mot_dataset",
+            "mot_seq",
         )
         with TestDir() as test_dir:
             voc_dir = osp.join(test_dir, "voc")

--- a/tests/cli/test_voc_format.py
+++ b/tests/cli/test_voc_format.py
@@ -230,7 +230,7 @@ class VocIntegrationScenarios(TestCase):
         expected_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
-                    id="1",
+                    id="000001",
                     subset="default",
                     media=Image(data=np.ones((16, 16, 3))),
                     annotations=[
@@ -257,7 +257,7 @@ class VocIntegrationScenarios(TestCase):
         )
 
         mot_dir = osp.join(
-            __file__[: __file__.rfind(osp.join("tests", ""))], "tests", "assets", "mot_dataset"
+            __file__[: __file__.rfind(osp.join("tests", ""))], "tests", "assets", "mot_dataset", "mot_seq"
         )
         with TestDir() as test_dir:
             voc_dir = osp.join(test_dir, "voc")

--- a/tests/cli/test_yolo_format.py
+++ b/tests/cli/test_yolo_format.py
@@ -60,13 +60,13 @@ class YoloIntegrationScenarios(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_export_mot_as_yolo(self):
         target_dataset = Dataset.from_iterable(
-            [DatasetItem(id="1", subset="train", annotations=[Bbox(0.0, 4.0, 4.0, 8.0, label=2)])],
+            [DatasetItem(id="000001", subset="train", annotations=[Bbox(0.0, 4.0, 4.0, 8.0, label=2)])],
             categories=["label_" + str(i) for i in range(10)],
         )
 
         with TestDir() as test_dir:
             mot_dir = osp.join(
-                __file__[: __file__.rfind(osp.join("tests", ""))], "tests", "assets", "mot_dataset"
+                __file__[: __file__.rfind(osp.join("tests", ""))], "tests", "assets", "mot_dataset", "mot_seq"
             )
 
             run(self, "create", "-o", test_dir)

--- a/tests/cli/test_yolo_format.py
+++ b/tests/cli/test_yolo_format.py
@@ -60,13 +60,21 @@ class YoloIntegrationScenarios(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_export_mot_as_yolo(self):
         target_dataset = Dataset.from_iterable(
-            [DatasetItem(id="000001", subset="train", annotations=[Bbox(0.0, 4.0, 4.0, 8.0, label=2)])],
+            [
+                DatasetItem(
+                    id="000001", subset="train", annotations=[Bbox(0.0, 4.0, 4.0, 8.0, label=2)]
+                )
+            ],
             categories=["label_" + str(i) for i in range(10)],
         )
 
         with TestDir() as test_dir:
             mot_dir = osp.join(
-                __file__[: __file__.rfind(osp.join("tests", ""))], "tests", "assets", "mot_dataset", "mot_seq"
+                __file__[: __file__.rfind(osp.join("tests", ""))],
+                "tests",
+                "assets",
+                "mot_dataset",
+                "mot_seq",
             )
 
             run(self, "create", "-o", test_dir)

--- a/tests/test_mot_format.py
+++ b/tests/test_mot_format.py
@@ -35,7 +35,7 @@ class MotConverterTest(TestCase):
         source_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
-                    id=1,
+                    id="000001",
                     subset="train",
                     media=Image(data=np.ones((16, 16, 3))),
                     annotations=[
@@ -63,7 +63,7 @@ class MotConverterTest(TestCase):
                     ],
                 ),
                 DatasetItem(
-                    id=2,
+                    id="000002",
                     subset="val",
                     media=Image(data=np.ones((8, 8, 3))),
                     annotations=[
@@ -71,7 +71,7 @@ class MotConverterTest(TestCase):
                     ],
                 ),
                 DatasetItem(
-                    id=3,
+                    id="000003",
                     subset="test",
                     media=Image(data=np.ones((5, 4, 3)) * 3),
                 ),
@@ -86,7 +86,7 @@ class MotConverterTest(TestCase):
         target_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
-                    id=1,
+                    id="000001",
                     media=Image(data=np.ones((16, 16, 3))),
                     annotations=[
                         Bbox(
@@ -127,7 +127,7 @@ class MotConverterTest(TestCase):
                     ],
                 ),
                 DatasetItem(
-                    id=2,
+                    id="000002",
                     media=Image(data=np.ones((8, 8, 3))),
                     annotations=[
                         Bbox(
@@ -145,7 +145,7 @@ class MotConverterTest(TestCase):
                     ],
                 ),
                 DatasetItem(
-                    id=3,
+                    id="000003",
                     media=Image(data=np.ones((5, 4, 3)) * 3),
                 ),
             ],
@@ -170,7 +170,7 @@ class MotConverterTest(TestCase):
         source_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
-                    id=1,
+                    id="000001",
                     media=Image(data=np.ones((16, 16, 3))),
                     annotations=[
                         Bbox(
@@ -188,7 +188,7 @@ class MotConverterTest(TestCase):
                     ],
                 ),
                 DatasetItem(
-                    id=2,
+                    id="000002",
                     media=Image(data=np.ones((8, 8, 3))),
                     annotations=[
                         Bbox(
@@ -257,7 +257,7 @@ class MotConverterTest(TestCase):
         source_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
-                    id=1,
+                    id="000001",
                     media=Image(data=np.ones((16, 16, 3))),
                     annotations=[
                         Bbox(
@@ -275,7 +275,7 @@ class MotConverterTest(TestCase):
                     ],
                 ),
                 DatasetItem(
-                    id=2,
+                    id="000002",
                     media=Image(data=np.ones((8, 8, 3))),
                     annotations=[
                         Bbox(
@@ -317,7 +317,7 @@ class MotImporterTest(TestCase):
         expected_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
-                    id=1,
+                    id="000001",
                     media=Image(data=np.ones((16, 16, 3))),
                     annotations=[
                         Bbox(

--- a/tests/test_mot_format.py
+++ b/tests/test_mot_format.py
@@ -170,7 +170,7 @@ class MotConverterTest(TestCase):
         source_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
-                    id="000001",
+                    id=1,
                     media=Image(data=np.ones((16, 16, 3))),
                     annotations=[
                         Bbox(
@@ -188,7 +188,7 @@ class MotConverterTest(TestCase):
                     ],
                 ),
                 DatasetItem(
-                    id="000002",
+                    id=2,
                     media=Image(data=np.ones((8, 8, 3))),
                     annotations=[
                         Bbox(
@@ -313,7 +313,13 @@ DUMMY_SEQINFO_DATASET_DIR = osp.join(
 
 
 class MotImporterTest(TestCase):
-    def _define_expected_dataset(self):
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_detect(self):
+        detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
+        self.assertEqual([MotSeqImporter.NAME], detected_formats)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_import(self):
         expected_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
@@ -338,24 +344,35 @@ class MotImporterTest(TestCase):
             categories=["label_" + str(label) for label in range(10)],
         )
 
-        return expected_dataset
-
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_detect(self):
-        detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
-        self.assertEqual([MotSeqImporter.NAME], detected_formats)
-
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_import(self):
-        expected_dataset = self._define_expected_dataset()
-
         dataset = Dataset.import_from(DUMMY_DATASET_DIR, "mot_seq")
 
         compare_datasets(self, expected_dataset, dataset)
 
     @mark_requirement(Requirements.DATUM_BUG_560)
     def test_can_import_seqinfo(self):
-        expected_dataset = self._define_expected_dataset()
+        expected_dataset = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id=1,
+                    media=Image(data=np.ones((16, 16, 3))),
+                    annotations=[
+                        Bbox(
+                            0,
+                            4,
+                            4,
+                            8,
+                            label=2,
+                            attributes={
+                                "occluded": False,
+                                "visibility": 1.0,
+                                "ignored": False,
+                            },
+                        ),
+                    ],
+                ),
+            ],
+            categories=["label_" + str(label) for label in range(10)],
+        )
 
         dataset = Dataset.import_from(DUMMY_SEQINFO_DATASET_DIR, "mot_seq")
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Import of projects in MOT format doesn't work now because the id of the elements doesn't match the name of the image. This PR fixes the issue.

- MOT format Item ids are changed from simple numbers to numbers with leading zeros.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
