### PR TITLE
[Dependent #22] Customized sly pointcloud format

### DIFF
--- a/datumaro/plugins/sly_pointcloud_format/converter.py
+++ b/datumaro/plugins/sly_pointcloud_format/converter.py
@@ -273,8 +273,8 @@ class _SuperviselyPointCloudDumper:
             )
 
             # format customization for CVAT
-            if 'keyframe' in ann.attributes:
-                item_ann_data["figures"][-1]['keyframe'] = ann.attributes['keyframe']
+            if "keyframe" in ann.attributes:
+                item_ann_data["figures"][-1]["keyframe"] = ann.attributes["keyframe"]
 
             figure_id = ann.id
             if self._context._reindex or figure_id is None:

--- a/datumaro/plugins/sly_pointcloud_format/converter.py
+++ b/datumaro/plugins/sly_pointcloud_format/converter.py
@@ -270,6 +270,11 @@ class _SuperviselyPointCloudDumper:
                     **ann_user_info,
                 }
             )
+
+            # format customization for CVAT
+            if 'keyframe' in ann.attributes:
+                item_ann_data["figures"][-1]['keyframe'] = ann.attributes['keyframe']
+
             figure_id = ann.id
             if self._context._reindex or figure_id is None:
                 figure_id = len(key_id_data["figures"]) + 1

--- a/datumaro/plugins/sly_pointcloud_format/converter.py
+++ b/datumaro/plugins/sly_pointcloud_format/converter.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
+# Copyright (C) 2023 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/plugins/sly_pointcloud_format/extractor.py
+++ b/datumaro/plugins/sly_pointcloud_format/extractor.py
@@ -121,7 +121,11 @@ class SuperviselyPointCloudExtractor(SourceExtractor):
                 label = categories[AnnotationType.label].find(obj["classTitle"])[0]
 
                 attributes = {}
-                attributes["track_id"] = obj["id"]
+                # format customization for CVAT
+                if "keyframe" in figure:
+                    attributes["track_id"] = obj["id"]
+                    attributes["keyframe"] = figure["keyframe"]
+
                 for tag in obj.get("tags", []):
                     attributes[tag["name"]] = _parse_tag(tag)
                 for attr in _get_label_attrs(label):

--- a/datumaro/plugins/sly_pointcloud_format/extractor.py
+++ b/datumaro/plugins/sly_pointcloud_format/extractor.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2023 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/plugins/sly_pointcloud_format/extractor.py
+++ b/datumaro/plugins/sly_pointcloud_format/extractor.py
@@ -123,8 +123,8 @@ class SuperviselyPointCloudExtractor(SourceExtractor):
 
                 attributes = {}
                 # format customization for CVAT
+                attributes["track_id"] = obj["id"]
                 if "keyframe" in figure:
-                    attributes["track_id"] = obj["id"]
                     attributes["keyframe"] = figure["keyframe"]
 
                 for tag in obj.get("tags", []):

--- a/datumaro/plugins/synthetic_data/utils.py
+++ b/datumaro/plugins/synthetic_data/utils.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import platform
 import warnings
 from contextlib import contextmanager
 from random import Random
@@ -116,6 +117,10 @@ def colorize(frame, net):
     img_l_rs = img_rs - 50  # subtract 50 for mean-centering
 
     net.setInput(cv.dnn.blobFromImage(img_l_rs))
+    if platform.system() == "Darwin" and hasattr(net, "enableWinograd"):
+        # TODO: We temporarily disable Winograd for MacOS because there is an OpenCV assertion error only for MacOS
+        # https://github.com/openvinotoolkit/datumaro/actions/runs/3851853611/jobs/6563454834#step:5:1199
+        net.enableWinograd(False)
     ab_dec = net.forward()[0, :, :, :].transpose((1, 2, 0))
 
     ab_dec_us = cv.resize(ab_dec, (W_orig, H_orig))

--- a/requirements-default.txt
+++ b/requirements-default.txt
@@ -1,2 +1,4 @@
 dvc>=2.7.0
+fsspec<2023.1; python_version == '3.7' # remove after 3.7 EOL. https://stackoverflow.com/a/75197382
+
 GitPython>=3.1.18,!=3.1.25 # https://github.com/openvinotoolkit/datumaro/issues/612


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
