### PR TITLE
Improve default mask crop behavior

### DIFF
--- a/datumaro/plugins/transforms.py
+++ b/datumaro/plugins/transforms.py
@@ -110,7 +110,9 @@ class CropCoveredSegments(ItemTransform, CliPlugin):
                     rle = mask_tools.mask_to_rle(s.image)
                 segments.append(rle)
 
-        segments = mask_tools.crop_covered_segments(segments, img_width, img_height)
+        segments = mask_tools.crop_covered_segments(
+            segments, img_width, img_height, ratio_tolerance=0
+        )
 
         new_anns = []
         for ann, new_segment in zip(segment_anns, segments):

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -22,9 +22,10 @@ class CompressedRle(TypedDict):
 
 
 Rle = Union[CompressedRle, UncompressedRle]
-Polygon = List[List[int]]
+Polygon = List[int]
+PolygonGroup = List[Polygon]
 BboxCoords = NamedTuple("BboxCoords", [("x", int), ("y", int), ("w", int), ("h", int)])
-Segment = Union[Polygon, Rle]
+Segment = Union[PolygonGroup, Rle]
 
 BinaryMask = NewType("BinaryMask", np.ndarray)
 IndexMask = NewType("IndexMask", np.ndarray)
@@ -234,7 +235,7 @@ def is_uncompressed_rle(obj: Segment) -> bool:
     return isinstance(obj, dict) and isinstance(obj.get("counts"), bytes)
 
 
-def is_polygon(obj: Segment) -> bool:
+def is_polygon_group(obj: Segment) -> bool:
     return (
         isinstance(obj, list)
         and isinstance(obj[0], list)
@@ -259,7 +260,7 @@ def crop_covered_segments(
     ratio_tolerance: float = 0.001,
     area_threshold: int = 1,
     return_masks: bool = False,
-) -> List[Union[Optional[BinaryMask], Polygon]]:
+) -> List[Union[Optional[BinaryMask], List[Polygon]]]:
     """
     Find all segments occluded by others and crop them to the visible part only.
     Input segments are expected to be sorted from background to foreground.
@@ -321,7 +322,7 @@ def crop_covered_segments(
 
             rles_top += rle_top
 
-        if not rles_top and is_polygon(wrapped_segments[i]) and not return_masks:
+        if not rles_top and is_polygon_group(wrapped_segments[i]) and not return_masks:
             output_segments.append(wrapped_segments[i])
             continue
 
@@ -335,7 +336,7 @@ def crop_covered_segments(
             bottom_mask -= top_mask
             bottom_mask[bottom_mask != 1] = 0
 
-        if not return_masks and is_polygon(wrapped_segments[i]):
+        if not return_masks and is_polygon_group(wrapped_segments[i]):
             output_segments.append(mask_to_polygons(bottom_mask, area_threshold=area_threshold))
         else:
             if np.sum(bottom_mask) < area_threshold:

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -314,9 +314,10 @@ def crop_covered_segments(
             area_top = sum(mask_utils.area(rle_top))
             area_ratio = area_top / area_bottom
 
-            # If a segment is already fully inside the top ones, stop accumulating the top
+            # If the top segment is (almost) fully inside the background one,
+            # we may need to skip it to avoid making a hole in the background object
             if abs(area_ratio - iou) < ratio_tolerance:
-                break
+                continue
 
             rles_top += rle_top
 

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -137,7 +137,7 @@ class PolygonConversionsTest(TestCase):
         expected = [
             # no changes expected
             mask_tools.rles_to_mask([initial[0]], *image_size),
-            mask_tools.rles_to_mask([initial[1]], *image_size)
+            mask_tools.rles_to_mask([initial[1]], *image_size),
         ]
 
         computed = mask_tools.crop_covered_segments(

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -115,6 +115,39 @@ class PolygonConversionsTest(TestCase):
         for i, (e_mask, c_mask) in enumerate(zip(expected, computed)):
             self.assertTrue(np.array_equal(e_mask, c_mask), "#%s: %s\n%s\n" % (i, e_mask, c_mask))
 
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_crop_covered_segments_and_avoid_holes_from_objects_inside_background_object(self):
+        image_size = [7, 7]
+        initial = [
+            [1, 1, 6, 1, 6, 6, 1, 6],
+            mask_tools.mask_to_rle(
+                np.array(
+                    [
+                        [0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 1, 1, 1, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0],
+                    ]
+                )
+            ),
+        ]
+        expected = [
+            # no changes expected
+            mask_tools.rles_to_mask([initial[0]], *image_size),
+            mask_tools.rles_to_mask([initial[1]], *image_size)
+        ]
+
+        computed = mask_tools.crop_covered_segments(
+            initial, *image_size, ratio_tolerance=0.1, return_masks=True
+        )
+
+        self.assertEqual(len(initial), len(computed))
+        for i, (e_mask, c_mask) in enumerate(zip(expected, computed)):
+            self.assertTrue(np.array_equal(e_mask, c_mask), "#%s: %s\n%s\n" % (i, e_mask, c_mask))
+
     def _test_mask_to_rle(self, source_mask):
         rle_uncompressed = mask_tools.mask_to_rle(source_mask)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Fixed segment crops for objects fully inside the background ones
- Improved default behavior for the `CropCoveredSegments` transform to avoid unexpected missing crops
- Improved type naming for polygon segments

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
