### PR TITLE
[GSoc2024] Added labels in dataset_meta.json of widerface_dataset to solve import issue #7258 of opencv/cvat

### DIFF
--- a/tests/assets/widerface_dataset/dataset_meta.json
+++ b/tests/assets/widerface_dataset/dataset_meta.json
@@ -1,3 +1,4 @@
 {
+"labels": ["face"],
 "label_map": {"0": "Parade", "1": "Handshaking"}
 }

--- a/tests/assets/widerface_dataset/dataset_meta.json
+++ b/tests/assets/widerface_dataset/dataset_meta.json
@@ -1,4 +1,3 @@
 {
-"labels": ["face"],
-"label_map": {"0": "Parade", "1": "Handshaking"}
+"labels": ["face"]
 }

--- a/tests/test_widerface_format.py
+++ b/tests/test_widerface_format.py
@@ -430,8 +430,8 @@ class WiderFaceImporterTest(TestCase):
                                 "pose": "0",
                                 "invalid": "0",
                             },
+                            label=0,
                         ),
-                        Label(0),
                     ],
                 ),
                 DatasetItem(
@@ -452,6 +452,7 @@ class WiderFaceImporterTest(TestCase):
                                 "pose": "0",
                                 "invalid": "0",
                             },
+                            label=0,
                         ),
                         Bbox(
                             5,
@@ -466,8 +467,8 @@ class WiderFaceImporterTest(TestCase):
                                 "pose": "0",
                                 "invalid": "0",
                             },
+                            label=0,
                         ),
-                        Label(1),
                     ],
                 ),
                 DatasetItem(
@@ -488,6 +489,7 @@ class WiderFaceImporterTest(TestCase):
                                 "pose": "2",
                                 "invalid": "0",
                             },
+                            label=0,
                         ),
                         Bbox(
                             3,
@@ -502,6 +504,7 @@ class WiderFaceImporterTest(TestCase):
                                 "pose": "0",
                                 "invalid": "0",
                             },
+                            label=0,
                         ),
                         Bbox(
                             5,
@@ -516,12 +519,12 @@ class WiderFaceImporterTest(TestCase):
                                 "pose": "2",
                                 "invalid": "0",
                             },
+                            label=0,
                         ),
-                        Label(0),
                     ],
                 ),
             ],
-            categories=["Parade", "Handshaking"],
+            categories=["face"],
         )
 
         dataset = Dataset.import_from(DUMMY_DATASET_DIR, "wider_face")


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
To fix the Widerface import issue which is being caused due to the missing labels in the widerface_dataset of datumaro, dataset_meta.json file has been edited by adding the "face" label, which the CVAT is looking for during its import process. fix [#7258](https://github.com/opencv/cvat/issues/7258) of opencv/cvat

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->



### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

This has been tested using the dataset [wf_dataset1.zip](https://github.com/cvat-ai/datumaro/files/14780731/wf_dataset1.zip)


### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
~~- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)~~
~~- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly~~
~~- [ ] I have added tests to cover my changes~~
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) 

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
~~- [ ] I have updated the license header for each file (see an example below)~~

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
