### PR TITLE
Refactor code for the updated features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/29>)
 - Incorrect writing of `media` field in the Datumaro format, when there are specific media fields
   (<https://github.com/cvat-ai/datumaro/pull/34>)
+- Added missing `PointCloud` media type in the datumaro module namespace
+  (<https://github.com/cvat-ai/datumaro/pull/34>)
 
 ### Security
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   <https://github.com/cvat-ai/datumaro/pull/15>)
 - Storing labels with the same name but with a different parent
   (<https://github.com/cvat-ai/datumaro/pull/8>)
+- Functions to work with plain polygons (COCO-style) - `close_polygon`, `simplify_polygon`
+  (<https://github.com/cvat-ai/datumaro/pull/39>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from functools import partial
-from itertools import chain
+from itertools import chain, repeat
 from typing import List, NamedTuple, NewType, Optional, Sequence, Tuple, TypedDict, Union
 
 import numpy as np
@@ -22,9 +22,15 @@ class CompressedRle(TypedDict):
 
 
 Rle = Union[CompressedRle, UncompressedRle]
+
 Polygon = List[int]
+"2d polygon with points [x1, y1, x2, y2, ...]"
+
 PolygonGroup = List[Polygon]
+"A group of polygons, describing a single object"
+
 BboxCoords = NamedTuple("BboxCoords", [("x", int), ("y", int), ("w", int), ("h", int)])
+
 Segment = Union[PolygonGroup, Rle]
 
 BinaryMask = NewType("BinaryMask", np.ndarray)
@@ -394,3 +400,37 @@ def merge_masks(
             merged_mask = np.where(m, m, merged_mask)
 
     return merged_mask
+
+
+def close_polygon(p: Polygon) -> Polygon:
+    """
+    Returns the closed version of the polygon (with the same first and last points),
+    or the polygon itself.
+    """
+    points = np.asarray(p).reshape((-1, 2))
+
+    if len(points) > 0 and not np.all(points[-1] == points[0]):
+        points = np.append(points, points[0])
+
+    return points.flatten().tolist()
+
+
+def simplify_polygon(p: Polygon) -> Polygon:
+    "Simplifies the polygon by removing repeated points"
+
+    points = np.asarray(p).reshape((-1, 2))
+    updated_points = []
+
+    if len(points) > 0:
+        updated_points.append(points[0])
+
+        for point_idx in range(1, len(points)):
+            prev_point = points[point_idx - 1]
+            point = points[point_idx]
+            if not np.all(point == prev_point):
+                updated_points.append(point)
+
+        if len(updated_points) < 3:
+            updated_points.extend(repeat(updated_points[-1], 3 - len(updated_points)))
+
+    return np.asarray(updated_points).flatten().tolist()

--- a/datumaro/util/mask_tools.py
+++ b/datumaro/util/mask_tools.py
@@ -278,8 +278,11 @@ def crop_covered_segments(
         iou_threshold: IoU threshold for objects to be counted as intersected
             By default is set to 0 to process any intersected objects
         ratio_tolerance: an IoU "handicap" value for a situation
-            when an object is (almost) fully covered by another one and we
-            don't want make a "hole" in the background object
+            when a foreground object is (almost) fully inside of another one,
+            and we don't want make a "hole" in the background object.
+            If the foreground object is fully or almost fully (iou - this ratio)
+            inside the background object, it will be kept.
+            The default is to keep tiny (0.1% of IoU) foreground objects.
         area_threshold: minimal area of included segments
 
     Returns:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR polishes some recently added code to make it clearer and more correct. Required to be used in CVAT.

- Fix invalid polygon comparison in tests
- Improve docstring for the updated `crop_covered_segments`'s `ratio_tolerance` parameter
- Added more functions for plain polygons, namely `close_polygon` and `simplify_polygon`

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
