### PR TITLE
Fix Dataset.get when there are transforms in the dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/34>)
 - Added missing `PointCloud` media type in the datumaro module namespace
   (<https://github.com/cvat-ai/datumaro/pull/34>)
+- `Dataset.get()` could ignore existing transforms in the dataset
+  (<https://github.com/cvat-ai/datumaro/pull/45>)
 
 ### Security
 - TBD

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -419,8 +419,9 @@ class DatasetStorage(IDataset):
         source = self._source or DatasetItemStorageDatasetView(
             self._storage, categories=self._categories, media_type=media_type
         )
-        transform = None
 
+        transform = None
+        old_ids = None
         if self._transforms:
             transform = _StackedTransform(source, self._transforms)
             if transform.is_local:

--- a/datumaro/components/dataset.py
+++ b/datumaro/components/dataset.py
@@ -588,7 +588,7 @@ class DatasetStorage(IDataset):
 
         item = self._storage.get(id, subset)
         if item is None and not self.is_cache_initialized():
-            if self._source.get.__func__ == Extractor.get:
+            if self._source.get.__func__ == Extractor.get or self._transforms:
                 # can be improved if IDataset is ABC
                 self.init_cache()
                 item = self._storage.get(id, subset)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1268,6 +1268,73 @@ class DatasetTest(TestCase):
         self.assertEqual(iter_called, 2)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_get_item_after_local_transforms(self):
+        iter_called = 0
+
+        class TestExtractor(Extractor):
+            def __iter__(self):
+                nonlocal iter_called
+                iter_called += 1
+                yield from [
+                    DatasetItem(1),
+                    DatasetItem(2),
+                    DatasetItem(3),
+                    DatasetItem(4),
+                ]
+
+        dataset = Dataset.from_extractors(TestExtractor())
+
+        class TestTransform(ItemTransform):
+            def transform_item(self, item):
+                return self.wrap_item(item, id=int(item.id) + 1)
+
+        dataset.transform(TestTransform)
+        dataset.transform(TestTransform)
+
+        self.assertEqual(iter_called, 0)
+
+        self.assertIsNotNone(dataset.get(3))
+        self.assertIsNotNone(dataset.get(4))
+        self.assertIsNotNone(dataset.get(5))
+        self.assertIsNotNone(dataset.get(6))
+
+        self.assertEqual(iter_called, 1)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_get_item_after_nonlocal_transforms(self):
+        iter_called = 0
+
+        class TestExtractor(Extractor):
+            def __iter__(self):
+                nonlocal iter_called
+                iter_called += 1
+                yield from [
+                    DatasetItem(1),
+                    DatasetItem(2),
+                    DatasetItem(3),
+                    DatasetItem(4),
+                ]
+
+        dataset = Dataset.from_extractors(TestExtractor())
+
+        class TestTransform(Transform):
+            def __iter__(self):
+                for item in self._extractor:
+                    yield self.wrap_item(item, id=int(item.id) + 1)
+
+        dataset.transform(TestTransform)
+        dataset.transform(TestTransform)
+
+        self.assertEqual(iter_called, 0)
+
+        self.assertIsNotNone(dataset.get(3))
+        self.assertIsNotNone(dataset.get(4))
+        self.assertIsNotNone(dataset.get(5))
+        self.assertIsNotNone(dataset.get(6))
+
+        self.assertEqual(iter_called, 2)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_get_subsets_after_local_transforms(self):
         iter_called = 0
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1293,6 +1293,8 @@ class DatasetTest(TestCase):
 
         self.assertEqual(iter_called, 0)
 
+        self.assertIsNone(dataset.get(1))
+        self.assertIsNone(dataset.get(2))
         self.assertIsNotNone(dataset.get(3))
         self.assertIsNotNone(dataset.get(4))
         self.assertIsNotNone(dataset.get(5))
@@ -1327,6 +1329,8 @@ class DatasetTest(TestCase):
 
         self.assertEqual(iter_called, 0)
 
+        self.assertIsNone(dataset.get(1))
+        self.assertIsNone(dataset.get(2))
         self.assertIsNotNone(dataset.get(3))
         self.assertIsNotNone(dataset.get(4))
         self.assertIsNotNone(dataset.get(5))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR fixes the problem with `Dataset.get()` method when there are transforms in the dataset - the applied transforms could be ignored before the patch. This could result in incorrect items returned or in other errors.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
