### PR TITLE
Fix collision in LabelCategories._indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TBD
 
 ### Fixed
+- Collision between parents and names in LabelCategories
+- (<https://github.com/cvat-ai/datumaro/pull/51>)
 - Detection for LFW format
   (<https://github.com/openvinotoolkit/datumaro/pull/680>)
 - Export of masks with background class with id != 0 in the VOC, KITTI and Cityscapes formats

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -106,7 +106,7 @@ class LabelCategories(Categories):
         parent: str = field(default="", validator=default_if_none(str))
         attributes: Set[str] = field(factory=set, validator=default_if_none(set))
 
-    items: List[str] = field(factory=list, validator=default_if_none(list))
+    items: List[Category] = field(factory=list, validator=default_if_none(list))
     _indices: Dict[Tuple[str, str], int] = field(factory=dict, init=False, eq=False)
 
     @classmethod

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) 2022-2024 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -150,7 +150,8 @@ class LabelCategories(Categories):
         indices = {}
         for index, item in enumerate(self.items):
             key = (item.parent, item.name)
-            assert key not in self._indices
+            if key in self._indices:
+                raise KeyError(f"Item with duplicate label {item.parent!r} {item.name!r}")
             indices[key] = index
         self._indices = indices
 
@@ -161,9 +162,11 @@ class LabelCategories(Categories):
     def add(
         self, name: str, parent: Optional[str] = "", attributes: Optional[Set[str]] = None
     ) -> int:
-        assert name
+        if not name:
+            raise ValueError("Label name must not be empty")
         key = (parent or "", name)
-        assert key not in self._indices
+        if key in self._indices:
+            raise KeyError(f"Label {parent!r} {name!r} already exists")
 
         index = len(self.items)
         self.items.append(self.Category(name, parent, attributes))

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -156,11 +156,7 @@ class LabelCategories(Categories):
 
     @property
     def labels(self):
-        return {
-            label_index: parent + name
-            for (parent, name), label_index
-            in self._indices.items()
-        }
+        return {label_index: parent + name for (parent, name), label_index in self._indices.items()}
 
     def add(
         self, name: str, parent: Optional[str] = "", attributes: Optional[Set[str]] = None

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -147,12 +147,12 @@ class LabelCategories(Categories):
         self._reindex()
 
     def _reindex(self):
-        self._indices = indices = {}
+        self._indices = {}
         for index, item in enumerate(self.items):
             key = (item.parent, item.name)
-            if key in indices:
+            if key in self._indices:
                 raise KeyError(f"Item with duplicate label {item.parent!r} {item.name!r}")
-            indices[key] = index
+            self._indices[key] = index
 
     @property
     def labels(self):

--- a/datumaro/components/annotation.py
+++ b/datumaro/components/annotation.py
@@ -147,13 +147,12 @@ class LabelCategories(Categories):
         self._reindex()
 
     def _reindex(self):
-        indices = {}
+        self._indices = indices = {}
         for index, item in enumerate(self.items):
             key = (item.parent, item.name)
-            if key in self._indices:
+            if key in indices:
                 raise KeyError(f"Item with duplicate label {item.parent!r} {item.name!r}")
             indices[key] = index
-        self._indices = indices
 
     @property
     def labels(self):

--- a/datumaro/plugins/camvid_format.py
+++ b/datumaro/plugins/camvid_format.py
@@ -198,8 +198,7 @@ class CamvidExtractor(SourceExtractor):
     def _load_items(self, path):
         items = {}
 
-        labels = self._categories[AnnotationType.label]._indices
-        labels = {labels[label_name]: label_name for label_name in labels}
+        labels = self._categories[AnnotationType.label].labels
 
         with open(path, encoding="utf-8") as f:
             for line in f:

--- a/datumaro/plugins/camvid_format.py
+++ b/datumaro/plugins/camvid_format.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2022 Intel Corporation
+# Copyright (C) 2022-2024 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -348,7 +348,7 @@ class _CocoExtractor(SourceExtractor):
                 for x, y, v in take_by(keypoints, 3):
                     sublabel = None
                     if i < len(sublabels):
-                        sublabel = label_cat.find(label_cat.items[label_id].name + sublabels[i])[0]
+                        sublabel = label_cat.find(sublabels[i], label_cat.items[label_id].name)[0]
                     points.append(Points([x, y], [v], label=sublabel))
                     i += 1
 

--- a/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/plugins/coco_format/extractor.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019-2022 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) 2022-2024 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -191,7 +191,9 @@ def compare_datasets(
                 ann_b_matches, lambda x: _compare_annotations(x, ann_a, ignored_attrs=ignored_attrs)
             )
             if ann_b is None:
-                test.fail("ann\n\t%s,\ncandidates\n\t%s" % (ann_a, "\n\t".join(map(str, ann_b_matches))))
+                test.fail(
+                    "ann\n\t%s,\ncandidates\n\t%s" % (ann_a, "\n\t".join(map(str, ann_b_matches)))
+                )
             item_b.annotations.remove(ann_b)  # avoid repeats
 
 

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -191,7 +191,7 @@ def compare_datasets(
                 ann_b_matches, lambda x: _compare_annotations(x, ann_a, ignored_attrs=ignored_attrs)
             )
             if ann_b is None:
-                test.fail("ann %s, candidates %s" % (ann_a, ann_b_matches))
+                test.fail("ann\n\t%s,\ncandidates\n\t%s" % (ann_a, "\n\t".join(map(str, ann_b_matches))))
             item_b.annotations.remove(ann_b)  # avoid repeats
 
 

--- a/tests/cli/test_revpath.py
+++ b/tests/cli/test_revpath.py
@@ -15,6 +15,7 @@ from datumaro.components.project import Project
 from datumaro.util.scope import scope_add, scoped
 from datumaro.util.test_utils import TestDir
 
+from ..conftest import ASSETS_DIR
 from ..requirements import Requirements, mark_requirement
 
 
@@ -133,13 +134,13 @@ class TestRevpath(TestCase):
         # create an ambiguous dataset by merging annotations from
         # datasets in different formats
         annotation_dir = osp.join(dataset_url, "training/street")
-        assets_dir = osp.join(osp.dirname(__file__), "../assets")
         os.makedirs(annotation_dir)
-        for asset in [
-            "ade20k2017_dataset/dataset/training/street/1_atr.txt",
-            "ade20k2020_dataset/dataset/training/street/1.json",
-        ]:
-            shutil.copy(osp.join(assets_dir, asset), annotation_dir)
+        for root, asset_name in (
+            ("ade20k2017_dataset", "1_atr.txt"),
+            ("ade20k2020_dataset", "1.json"),
+        ):
+            asset = ASSETS_DIR / root / "dataset" / "training" / "street" / asset_name
+            shutil.copy(asset, annotation_dir)
 
         with self.subTest("no context"):
             with self.assertRaises(WrongRevpathError) as cm:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,14 @@
 # Copyright (C) 2022-2024 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
+from pathlib import Path
+
 from datumaro.util.test_utils import TestDir
 
 from .fixtures import *
 from .utils.test_utils import TestCaseHelper
+
+ASSETS_DIR = Path(__file__).parent / "assets"
 
 
 def pytest_configure(config):

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -1,8 +1,11 @@
 import pytest
 
 from datumaro import LabelCategories
+from tests.requirements import Requirements
+from tests.requirements import mark_requirement
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_add_category():
     categories = LabelCategories()
     index = categories.add("cat")
@@ -11,6 +14,7 @@ def test_add_category():
     assert categories[0].name == "cat"
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_add_category_with_parent():
     categories = LabelCategories()
     index = categories.add("cat", parent="animal")
@@ -20,6 +24,7 @@ def test_add_category_with_parent():
     assert categories[0].parent == "animal"
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_add_category_with_attributes():
     categories = LabelCategories()
     attributes = {"color", "size"}
@@ -29,17 +34,16 @@ def test_add_category_with_attributes():
     assert categories[0].attributes == attributes
 
 
-def test_add_duplicate_category():
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
+@pytest.mark.parametrize("name,parent", [("cat", "animal"), ("cat", "")])
+def test_add_duplicate_category(name, parent):
     categories = LabelCategories()
-    categories.add("cat")
-    with pytest.raises(KeyError, match="Label '' 'cat' already exists"):
-        categories.add("cat")
-
-    categories.add("cat", parent="animal")
-    with pytest.raises(KeyError, match="Label 'animal' 'cat' already exists"):
-        categories.add("cat", parent="animal")
+    categories.add(name, parent=parent)
+    with pytest.raises(KeyError, match=f"Label '{parent}' '{name}' already exists"):
+        categories.add(name, parent=parent)
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_potential_collision():
     """
     Previously indices were computed as (parent or "") + name
@@ -55,6 +59,7 @@ def test_potential_collision():
     assert categories.items[1].parent == "parent2"
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_find_category():
     categories = LabelCategories()
     categories.add("cat")
@@ -63,6 +68,7 @@ def test_find_category():
     assert category.name == "cat"
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_find_non_existent_category():
     categories = LabelCategories()
     index, category = categories.find("dog")
@@ -70,6 +76,7 @@ def test_find_non_existent_category():
     assert category is None
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_from_iterable():
     categories = LabelCategories.from_iterable(["cat", "dog"])
     assert len(categories) == 2
@@ -77,6 +84,7 @@ def test_from_iterable():
     assert categories[1].name == "dog"
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_from_iterable_with_parents():
     categories = LabelCategories.from_iterable([("cat", "animal"), ("dog", "animal")])
     assert len(categories) == 2
@@ -86,6 +94,7 @@ def test_from_iterable_with_parents():
     assert categories[1].parent == "animal"
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_from_iterable_with_attributes():
     categories = LabelCategories.from_iterable([("cat", "animal", ["color", "size"])])
     assert len(categories) == 1
@@ -94,6 +103,7 @@ def test_from_iterable_with_attributes():
     assert categories[0].attributes == {"color", "size"}
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_reindex():
     categories = LabelCategories()
     categories.add("cat")
@@ -101,6 +111,7 @@ def test_reindex():
     assert len(categories._indices) == 2
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_labels_property():
     categories = LabelCategories()
     categories.add("cat")
@@ -110,6 +121,7 @@ def test_labels_property():
     assert labels[1] == "animaldog"
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_len():
     categories = LabelCategories()
     assert len(categories) == 0
@@ -117,6 +129,7 @@ def test_len():
     assert len(categories) == 1
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_contains():
     categories = LabelCategories()
     categories.add("cat")
@@ -124,6 +137,7 @@ def test_contains():
     assert "dog" not in categories
 
 
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_iter():
     categories = LabelCategories()
     categories.add("cat")

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -109,10 +109,27 @@ def test_can_construct_from_iterable_with_attributes():
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
 def test_can_reindex_on_init():
-    categories = LabelCategories()
-    categories.add("cat")
-    categories.add("dog", parent="animal")
-    assert len(categories._indices) == 2
+    categories = LabelCategories(
+        items=[
+            cat_category := LabelCategories.Category("cat"),
+            dog_category := LabelCategories.Category("dog", "animal"),
+        ]
+    )
+    assert categories._indices == {("", "cat"): 0, ("animal", "dog"): 1}
+    assert categories.find("cat") == (0, cat_category)
+    assert categories.find("dog", parent="animal") == (1, dog_category)
+    assert categories.find("dog") == (None, None)
+
+
+@mark_requirement(Requirements.DATUM_GENERAL_REQ)
+def test_cant_reindex_on_init():
+    with pytest.raises(KeyError, match="Item with duplicate label '' 'cat'"):
+        LabelCategories(
+            items=[
+                cat_category := LabelCategories.Category("cat"),
+                cat_category,
+            ]
+        )
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -39,6 +39,8 @@ def test_add_duplicate_category():
 def test_potential_collision():
     """
     Previously indices were computed as (parent or "") + name
+
+    See https://github.com/cvat-ai/datumaro/pull/51
     """
     categories = LabelCategories()
     categories.add("22", parent="parent")

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -5,6 +5,7 @@
 import pytest
 
 from datumaro import LabelCategories
+
 from tests.requirements import Requirements, mark_requirement
 
 

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -1,8 +1,7 @@
 import pytest
 
 from datumaro import LabelCategories
-from tests.requirements import Requirements
-from tests.requirements import mark_requirement
+from tests.requirements import Requirements, mark_requirement
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -10,7 +10,7 @@ from tests.requirements import Requirements, mark_requirement
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_add_category():
+def test_can_add_category():
     categories = LabelCategories()
     index = categories.add("cat")
     assert index == 0
@@ -19,7 +19,7 @@ def test_add_category():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_add_category_with_parent():
+def test_can_add_category_with_parent():
     categories = LabelCategories()
     index = categories.add("cat", parent="animal")
     assert index == 0
@@ -29,7 +29,7 @@ def test_add_category_with_parent():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_add_category_with_attributes():
+def test_can_add_category_with_attributes():
     categories = LabelCategories()
     attributes = {"color", "size"}
     index = categories.add("cat", attributes=attributes)
@@ -40,7 +40,7 @@ def test_add_category_with_attributes():
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
 @pytest.mark.parametrize("name,parent", [("cat", "animal"), ("cat", "")])
-def test_add_duplicate_category(name, parent):
+def test_can_add_duplicate_category(name, parent):
     categories = LabelCategories()
     categories.add(name, parent=parent)
     with pytest.raises(KeyError, match=f"Label '{parent}' '{name}' already exists"):
@@ -48,7 +48,7 @@ def test_add_duplicate_category(name, parent):
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_potential_collision():
+def test_can_resolve_potential_collision():
     """
     Previously indices were computed as (parent or "") + name
 
@@ -64,7 +64,7 @@ def test_potential_collision():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_find_category():
+def test_can_find_category():
     categories = LabelCategories()
     categories.add("cat")
     index, category = categories.find("cat")
@@ -73,7 +73,7 @@ def test_find_category():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_find_non_existent_category():
+def test_cant_find_non_existent_category():
     categories = LabelCategories()
     index, category = categories.find("dog")
     assert index is None
@@ -81,7 +81,7 @@ def test_find_non_existent_category():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_from_iterable():
+def test_can_construct_from_iterable():
     categories = LabelCategories.from_iterable(["cat", "dog"])
     assert len(categories) == 2
     assert categories[0].name == "cat"
@@ -89,7 +89,7 @@ def test_from_iterable():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_from_iterable_with_parents():
+def test_can_construct_from_iterable_with_parents():
     categories = LabelCategories.from_iterable([("cat", "animal"), ("dog", "animal")])
     assert len(categories) == 2
     assert categories[0].name == "cat"
@@ -99,7 +99,7 @@ def test_from_iterable_with_parents():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_from_iterable_with_attributes():
+def test_can_construct_from_iterable_with_attributes():
     categories = LabelCategories.from_iterable([("cat", "animal", ["color", "size"])])
     assert len(categories) == 1
     assert categories[0].name == "cat"
@@ -108,7 +108,7 @@ def test_from_iterable_with_attributes():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_reindex():
+def test_can_reindex_on_init():
     categories = LabelCategories()
     categories.add("cat")
     categories.add("dog", parent="animal")
@@ -116,7 +116,7 @@ def test_reindex():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_labels_property():
+def test_has_labels_property():
     categories = LabelCategories()
     categories.add("cat")
     categories.add("dog", parent="animal")
@@ -126,7 +126,7 @@ def test_labels_property():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_len():
+def test_has_len():
     categories = LabelCategories()
     assert len(categories) == 0
     categories.add("cat")
@@ -134,7 +134,7 @@ def test_len():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_contains():
+def test_has_contains():
     categories = LabelCategories()
     categories.add("cat")
     assert "cat" in categories
@@ -142,7 +142,7 @@ def test_contains():
 
 
 @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-def test_iter():
+def test_can_iter():
     categories = LabelCategories()
     categories.add("cat")
     categories.add("dog")

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2024 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import pytest
 
 from datumaro import LabelCategories

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -1,5 +1,5 @@
-
 import pytest
+
 from datumaro import LabelCategories
 
 

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -32,8 +32,12 @@ def test_add_category_with_attributes():
 def test_add_duplicate_category():
     categories = LabelCategories()
     categories.add("cat")
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="Label '' 'cat' already exists"):
         categories.add("cat")
+
+    categories.add("cat", parent="animal")
+    with pytest.raises(KeyError, match="Label 'animal' 'cat' already exists"):
+        categories.add("cat", parent="animal")
 
 
 def test_potential_collision():

--- a/tests/test_label_categories.py
+++ b/tests/test_label_categories.py
@@ -1,0 +1,128 @@
+
+import pytest
+from datumaro import LabelCategories
+
+
+def test_add_category():
+    categories = LabelCategories()
+    index = categories.add("cat")
+    assert index == 0
+    assert len(categories) == 1
+    assert categories[0].name == "cat"
+
+
+def test_add_category_with_parent():
+    categories = LabelCategories()
+    index = categories.add("cat", parent="animal")
+    assert index == 0
+    assert len(categories) == 1
+    assert categories[0].name == "cat"
+    assert categories[0].parent == "animal"
+
+
+def test_add_category_with_attributes():
+    categories = LabelCategories()
+    attributes = {"color", "size"}
+    index = categories.add("cat", attributes=attributes)
+    assert index == 0
+    assert len(categories) == 1
+    assert categories[0].attributes == attributes
+
+
+def test_add_duplicate_category():
+    categories = LabelCategories()
+    categories.add("cat")
+    with pytest.raises(KeyError):
+        categories.add("cat")
+
+
+def test_potential_collision():
+    """
+    Previously indices were computed as (parent or "") + name
+    """
+    categories = LabelCategories()
+    categories.add("22", parent="parent")
+    categories.add("2", parent="parent2")
+    assert categories.items[0].name == "22"
+    assert categories.items[0].parent == "parent"
+    assert categories.items[1].name == "2"
+    assert categories.items[1].parent == "parent2"
+
+
+def test_find_category():
+    categories = LabelCategories()
+    categories.add("cat")
+    index, category = categories.find("cat")
+    assert index == 0
+    assert category.name == "cat"
+
+
+def test_find_non_existent_category():
+    categories = LabelCategories()
+    index, category = categories.find("dog")
+    assert index is None
+    assert category is None
+
+
+def test_from_iterable():
+    categories = LabelCategories.from_iterable(["cat", "dog"])
+    assert len(categories) == 2
+    assert categories[0].name == "cat"
+    assert categories[1].name == "dog"
+
+
+def test_from_iterable_with_parents():
+    categories = LabelCategories.from_iterable([("cat", "animal"), ("dog", "animal")])
+    assert len(categories) == 2
+    assert categories[0].name == "cat"
+    assert categories[0].parent == "animal"
+    assert categories[1].name == "dog"
+    assert categories[1].parent == "animal"
+
+
+def test_from_iterable_with_attributes():
+    categories = LabelCategories.from_iterable([("cat", "animal", ["color", "size"])])
+    assert len(categories) == 1
+    assert categories[0].name == "cat"
+    assert categories[0].parent == "animal"
+    assert categories[0].attributes == {"color", "size"}
+
+
+def test_reindex():
+    categories = LabelCategories()
+    categories.add("cat")
+    categories.add("dog", parent="animal")
+    assert len(categories._indices) == 2
+
+
+def test_labels_property():
+    categories = LabelCategories()
+    categories.add("cat")
+    categories.add("dog", parent="animal")
+    labels = categories.labels
+    assert labels[0] == "cat"
+    assert labels[1] == "animaldog"
+
+
+def test_len():
+    categories = LabelCategories()
+    assert len(categories) == 0
+    categories.add("cat")
+    assert len(categories) == 1
+
+
+def test_contains():
+    categories = LabelCategories()
+    categories.add("cat")
+    assert "cat" in categories
+    assert "dog" not in categories
+
+
+def test_iter():
+    categories = LabelCategories()
+    categories.add("cat")
+    categories.add("dog")
+    items = list(categories)
+    assert len(items) == 2
+    assert items[0].name == "cat"
+    assert items[1].name == "dog"

--- a/tests/test_mars_format.py
+++ b/tests/test_mars_format.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os.path as osp
 from unittest.case import TestCase
 
 import numpy as np

--- a/tests/test_mars_format.py
+++ b/tests/test_mars_format.py
@@ -14,10 +14,10 @@ from datumaro.components.media import Image
 from datumaro.plugins.mars_format import MarsImporter
 from datumaro.util.test_utils import compare_datasets
 
+from tests.conftest import ASSETS_DIR
 from tests.requirements import Requirements, mark_requirement
 
-ASSETS_DIR = osp.join(osp.dirname(__file__), "assets")
-DUMMY_MARS_DATASET = osp.join(ASSETS_DIR, "mars_dataset")
+DUMMY_MARS_DATASET = str(ASSETS_DIR / "mars_dataset")
 
 
 class MarsImporterTest(TestCase):

--- a/tests/test_open_images_format.py
+++ b/tests/test_open_images_format.py
@@ -17,6 +17,7 @@ from datumaro.components.media import Image
 from datumaro.plugins.open_images_format import OpenImagesConverter, OpenImagesImporter
 from datumaro.util.test_utils import TestDir, compare_datasets
 
+from tests.conftest import ASSETS_DIR
 from tests.requirements import Requirements, mark_requirement
 
 
@@ -308,10 +309,8 @@ class OpenImagesFormatTest(TestCase):
             compare_datasets(self, dataset, parsed_dataset, require_media=True)
 
 
-ASSETS_DIR = osp.join(osp.dirname(__file__), "assets")
-
-DUMMY_DATASET_DIR_V6 = osp.join(ASSETS_DIR, "open_images_dataset/v6")
-DUMMY_DATASET_DIR_V5 = osp.join(ASSETS_DIR, "open_images_dataset/v5")
+DUMMY_DATASET_DIR_V6 = str(ASSETS_DIR / "open_images_dataset" / "v6")
+DUMMY_DATASET_DIR_V5 = str(ASSETS_DIR / "open_images_dataset" / "v5")
 
 
 class OpenImagesImporterTest(TestCase):

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -12,8 +12,8 @@ from datumaro.components.media import Image
 from datumaro.components.project import Dataset
 from datumaro.plugins.sampler.random_sampler import LabelRandomSampler, RandomSampler
 from datumaro.util.test_utils import compare_datasets, compare_datasets_strict
-from .conftest import ASSETS_DIR
 
+from .conftest import ASSETS_DIR
 
 try:
     import pandas as pd

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -12,6 +12,8 @@ from datumaro.components.media import Image
 from datumaro.components.project import Dataset
 from datumaro.plugins.sampler.random_sampler import LabelRandomSampler, RandomSampler
 from datumaro.util.test_utils import compare_datasets, compare_datasets_strict
+from .conftest import ASSETS_DIR
+
 
 try:
     import pandas as pd
@@ -31,8 +33,8 @@ class TestRelevancySampler(TestCase):
     @staticmethod
     def _get_probs(out_range=False):
         probs = []
-        inference_file = "tests/assets/sampler/inference.csv"
-        with open(inference_file) as csv_file:
+        inference_file = ASSETS_DIR / "sampler" / "inference.csv"
+        with inference_file.open() as csv_file:
             csv_reader = csv.reader(csv_file)
             col = 0
             for row in csv_reader:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
Now indices keys in LabelCategories are computed as (parent or "") + name.
This may result in a collision with
```python
name1 = "22"
parent1 = "parent"
name2 = "parent2"
name2 = "2"

parent1 + name1 == parent2 + name2
```
So this code would fail:
```python
categories = LabelCategories()
categories.add("22", parent="parent")
categories.add("2", parent="parent2")  # AssertionError
```

Changing keys formula to `(parent, name)` (`tuple[str, str]`) solves the issue

### How to test
Changes include `tests.test_label_categories.test_potential_collision` that tests this exact behaviour.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ x I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `labels` property in the `Category` class for easier access to label information.
  
- **Improvements**
	- Enhanced the clarity and organization of label indexing in the `Category` class.
	- Simplified label retrieval in the `camvid_format` plugin, improving readability and potentially performance.
	- Clarified the logic for determining `sublabel` in the `coco_format` extractor.

- **Bug Fixes**
	- Improved error message formatting in the `compare_datasets` function for better readability during test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->