### PR TITLE
ignoring point order in skeleton annotations when comparing annotations

### DIFF
--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -1870,11 +1870,11 @@ class ExactComparator:
         if a.type == b.type == AnnotationType.skeleton and "elements" not in ignored_fields:
             a_fields["elements"] = sorted(
                 filter(lambda p: p.visibility[0] != Points.Visibility.absent, a.elements),
-                key=lambda s: s.label,
+                key=lambda s: s.label or -1,
             )
             b_fields["elements"] = sorted(
                 filter(lambda p: p.visibility[0] != Points.Visibility.absent, b.elements),
-                key=lambda s: s.label,
+                key=lambda s: s.label or -1,
             )
 
         result = a.wrap(**a_fields) == b.wrap(**b_fields)

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -37,6 +37,7 @@ from datumaro.components.annotation import (
     Label,
     LabelCategories,
     MaskCategories,
+    Points,
     PointsCategories,
 )
 from datumaro.components.cli_plugin import CliPlugin
@@ -1856,7 +1857,7 @@ class ExactComparator:
             except AssertionError as e:
                 errors.append({"type": "points", "message": str(e)})
 
-    def _compare_annotations(self, a, b):
+    def _compare_annotations(self, a: Annotation, b: Annotation):
         ignored_fields = self.ignored_fields
         ignored_attrs = self.ignored_attrs
 
@@ -1865,6 +1866,16 @@ class ExactComparator:
         if "attributes" not in ignored_fields:
             a_fields["attributes"] = filter_dict(a.attributes, ignored_attrs)
             b_fields["attributes"] = filter_dict(b.attributes, ignored_attrs)
+
+        if a.type == b.type == AnnotationType.skeleton and "elements" not in ignored_fields:
+            a_fields["elements"] = sorted(
+                filter(lambda p: p.visibility[0] != Points.Visibility.absent, a.elements),
+                key=lambda s: s.label,
+            )
+            b_fields["elements"] = sorted(
+                filter(lambda p: p.visibility[0] != Points.Visibility.absent, b.elements),
+                key=lambda s: s.label,
+            )
 
         result = a.wrap(**a_fields) == b.wrap(**b_fields)
 

--- a/datumaro/components/operations.py
+++ b/datumaro/components/operations.py
@@ -1870,11 +1870,11 @@ class ExactComparator:
         if a.type == b.type == AnnotationType.skeleton and "elements" not in ignored_fields:
             a_fields["elements"] = sorted(
                 filter(lambda p: p.visibility[0] != Points.Visibility.absent, a.elements),
-                key=lambda s: s.label or -1,
+                key=lambda p: p.label if p.label is not None else -1,
             )
             b_fields["elements"] = sorted(
                 filter(lambda p: p.visibility[0] != Points.Visibility.absent, b.elements),
-                key=lambda s: s.label or -1,
+                key=lambda p: p.label if p.label is not None else -1,
             )
 
         result = a.wrap(**a_fields) == b.wrap(**b_fields)

--- a/datumaro/plugins/yolo_format/converter.py
+++ b/datumaro/plugins/yolo_format/converter.py
@@ -194,6 +194,10 @@ class YoloConverter(Converter):
         except Exception as e:
             self._ctx.error_policy.report_item_error(e, item_id=(item.id, item.subset))
 
+    def _save_annotation_file(self, annotation_path, yolo_annotation):
+        with open(annotation_path, "w", encoding="utf-8") as f:
+            f.write(yolo_annotation)
+
     def _export_item_annotation(self, item: DatasetItem, subset_dir: str) -> None:
         try:
             height, width = item.media.size
@@ -208,8 +212,7 @@ class YoloConverter(Converter):
             annotation_path = osp.join(subset_dir, f"{item.id}{YoloPath.LABELS_EXT}")
             os.makedirs(osp.dirname(annotation_path), exist_ok=True)
 
-            with open(annotation_path, "w", encoding="utf-8") as f:
-                f.write(yolo_annotation)
+            self._save_annotation_file(annotation_path, yolo_annotation)
 
         except Exception as e:
             self._ctx.error_policy.report_item_error(e, item_id=(item.id, item.subset))
@@ -288,9 +291,9 @@ class YOLOv8DetectionConverter(YoloConverter):
         super().__init__(extractor, save_dir, add_path_prefix=add_path_prefix, **kwargs)
         self._config_filename = config_file or YOLOv8Path.DEFAULT_CONFIG_FILE
 
-    def _export_item_annotation(self, item: DatasetItem, subset_dir: str) -> None:
-        if len(item.annotations) > 0:
-            super()._export_item_annotation(item, subset_dir)
+    def _save_annotation_file(self, annotation_path, yolo_annotation):
+        if yolo_annotation:
+            super()._save_annotation_file(annotation_path, yolo_annotation)
 
     @classmethod
     def build_cmdline_parser(cls, **kwargs):

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -121,7 +121,7 @@ def compare_annotations(expected: Annotation, actual: Annotation, ignored_attrs=
     if not ignored_attrs and not is_skeleton:
         return expected == actual
 
-    ignored_attrs = ignored_attrs or {}
+    ignored_attrs = ignored_attrs or []
 
     expected = copy(expected)
     actual = copy(actual)
@@ -136,11 +136,11 @@ def compare_annotations(expected: Annotation, actual: Annotation, ignored_attrs=
     if is_skeleton:
         expected.elements = sorted(
             filter(lambda p: p.visibility[0] != Points.Visibility.absent, expected.elements),
-            key=lambda s: s.label or -1,
+            key=lambda p: p.label if p.label is not None else -1,
         )
         actual.elements = sorted(
             filter(lambda p: p.visibility[0] != Points.Visibility.absent, actual.elements),
-            key=lambda s: s.label or -1,
+            key=lambda p: p.label if p.label is not None else -1,
         )
 
     return expected == actual

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -121,6 +121,8 @@ def compare_annotations(expected: Annotation, actual: Annotation, ignored_attrs=
     if not ignored_attrs and not is_skeleton:
         return expected == actual
 
+    ignored_attrs = ignored_attrs or {}
+
     expected = copy(expected)
     actual = copy(actual)
 

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -136,11 +136,11 @@ def compare_annotations(expected: Annotation, actual: Annotation, ignored_attrs=
     if is_skeleton:
         expected.elements = sorted(
             filter(lambda p: p.visibility[0] != Points.Visibility.absent, expected.elements),
-            key=lambda s: s.label,
+            key=lambda s: s.label or -1,
         )
         actual.elements = sorted(
             filter(lambda p: p.visibility[0] != Points.Visibility.absent, actual.elements),
-            key=lambda s: s.label,
+            key=lambda s: s.label or -1,
         )
 
     return expected == actual

--- a/datumaro/util/test_utils.py
+++ b/datumaro/util/test_utils.py
@@ -10,6 +10,7 @@ import tempfile
 import unittest
 import unittest.mock
 import warnings
+from copy import copy
 from enum import Enum, auto
 from glob import glob
 from typing import Any, Callable, Collection, Optional, Union
@@ -120,27 +121,24 @@ def compare_annotations(expected: Annotation, actual: Annotation, ignored_attrs=
     if not ignored_attrs and not is_skeleton:
         return expected == actual
 
+    expected = copy(expected)
+    actual = copy(actual)
+
     if ignored_attrs != IGNORE_ALL:
-        expected = expected.wrap(
-            attributes=filter_dict(expected.attributes, exclude_keys=ignored_attrs)
-        )
-        actual = actual.wrap(attributes=filter_dict(actual.attributes, exclude_keys=ignored_attrs))
+        expected.attributes = filter_dict(expected.attributes, exclude_keys=ignored_attrs)
+        actual.attributes = filter_dict(actual.attributes, exclude_keys=ignored_attrs)
     else:
-        expected = expected.wrap(attributes={})
-        actual = actual.wrap(attributes={})
+        expected.attributes = {}
+        actual.attributes = {}
 
     if is_skeleton:
-        expected = expected.wrap(
-            elements=sorted(
-                filter(lambda p: p.visibility[0] != Points.Visibility.absent, expected.elements),
-                key=lambda s: s.label,
-            )
+        expected.elements = sorted(
+            filter(lambda p: p.visibility[0] != Points.Visibility.absent, expected.elements),
+            key=lambda s: s.label,
         )
-        actual = actual.wrap(
-            elements=sorted(
-                filter(lambda p: p.visibility[0] != Points.Visibility.absent, actual.elements),
-                key=lambda s: s.label,
-            )
+        actual.elements = sorted(
+            filter(lambda p: p.visibility[0] != Points.Visibility.absent, actual.elements),
+            key=lambda s: s.label,
         )
 
     return expected == actual

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -302,9 +302,9 @@ class ExactComparatorTest(TestCase):
                     annotations=[
                         Skeleton(
                             [
-                                Points([0, 1], [2]),
-                                Points([1, 2], [1], label=2),
-                                Points([2, 3], [0], label=3),
+                                Points([0, 1], [Points.Visibility.visible]),
+                                Points([1, 2], [Points.Visibility.hidden], label=2),
+                                Points([2, 3], [Points.Visibility.absent], label=3),
                             ],
                             label=0,
                         )
@@ -315,9 +315,9 @@ class ExactComparatorTest(TestCase):
                     annotations=[
                         Skeleton(
                             [
-                                Points([4, 5], [2], label=1),
-                                Points([5, 6], [1], label=2),
-                                Points([6, 7], [0], label=3),
+                                Points([4, 5], [Points.Visibility.visible], label=1),
+                                Points([5, 6], [Points.Visibility.hidden], label=2),
+                                Points([6, 7], [Points.Visibility.absent], label=3),
                             ],
                             label=0,
                         )
@@ -328,9 +328,9 @@ class ExactComparatorTest(TestCase):
                     annotations=[
                         Skeleton(
                             [
-                                Points([7, 8], [2], label=1),
-                                Points([8, 9], [1], label=2),
-                                Points([9, 10], [0], label=3),
+                                Points([7, 8], [Points.Visibility.visible], label=1),
+                                Points([8, 9], [Points.Visibility.hidden], label=2),
+                                Points([9, 10], [Points.Visibility.absent], label=3),
                             ],
                             label=0,
                         )
@@ -347,8 +347,8 @@ class ExactComparatorTest(TestCase):
                     annotations=[
                         Skeleton(
                             [
-                                Points([1, 2], [1], label=2),
-                                Points([0, 1], [2]),
+                                Points([1, 2], [Points.Visibility.hidden], label=2),
+                                Points([0, 1], [Points.Visibility.absent]),
                             ],
                             label=0,
                         )
@@ -359,9 +359,9 @@ class ExactComparatorTest(TestCase):
                     annotations=[
                         Skeleton(
                             [
-                                Points([4, 5], [2], label=1),
-                                Points([5, 6], [1], label=2),
-                                Points([6, 8], [0], label=3),
+                                Points([4, 5], [Points.Visibility.visible], label=1),
+                                Points([5, 6], [Points.Visibility.hidden], label=2),
+                                Points([6, 8], [Points.Visibility.absent], label=3),
                             ],
                             label=0,
                         )
@@ -372,9 +372,9 @@ class ExactComparatorTest(TestCase):
                     annotations=[
                         Skeleton(
                             [
-                                Points([7, 8], [2], label=1),
-                                Points([8, 10], [1], label=2),
-                                Points([9, 10], [0], label=3),
+                                Points([7, 8], [Points.Visibility.visible], label=1),
+                                Points([8, 10], [Points.Visibility.hidden], label=2),
+                                Points([9, 10], [Points.Visibility.absent], label=3),
                             ],
                             label=0,
                         )

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -348,7 +348,7 @@ class ExactComparatorTest(TestCase):
                         Skeleton(
                             [
                                 Points([1, 2], [Points.Visibility.hidden], label=2),
-                                Points([0, 1], [Points.Visibility.absent]),
+                                Points([0, 1], [Points.Visibility.visible]),
                             ],
                             label=0,
                         )

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -302,7 +302,7 @@ class ExactComparatorTest(TestCase):
                     annotations=[
                         Skeleton(
                             [
-                                Points([0, 1], [2], label=1),
+                                Points([0, 1], [2]),
                                 Points([1, 2], [1], label=2),
                                 Points([2, 3], [0], label=3),
                             ],
@@ -348,7 +348,7 @@ class ExactComparatorTest(TestCase):
                         Skeleton(
                             [
                                 Points([1, 2], [1], label=2),
-                                Points([0, 1], [2], label=1),
+                                Points([0, 1], [2]),
                             ],
                             label=0,
                         )

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -469,6 +469,7 @@ class YOLOv8DetectionConverterTest(YoloConverterTest):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_without_creating_annotation_file_and_load(self, test_dir):
+        categories = self._generate_random_dataset([]).categories()
         source_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
@@ -481,7 +482,7 @@ class YOLOv8DetectionConverterTest(YoloConverterTest):
                     ],
                 )
             ],
-            categories=["label_" + str(i) for i in range(5)],
+            categories=categories,
         )
         expected_dataset = Dataset.from_iterable(
             [
@@ -491,7 +492,7 @@ class YOLOv8DetectionConverterTest(YoloConverterTest):
                     media=Image(data=np.ones((8, 8, 3))),
                 )
             ],
-            categories=["label_" + str(i) for i in range(5)],
+            categories=categories,
         )
         self.CONVERTER.convert(source_dataset, test_dir, save_media=True)
         assert os.listdir(osp.join(test_dir, "labels", "train")) == []
@@ -896,37 +897,6 @@ class YOLOv8PoseConverterTest(YOLOv8DetectionConverterTest):
         with open(osp.join(test_dir, "data.yaml"), "r") as f:
             config = yaml.safe_load(f)
             assert config["names"] == {0: "skeleton"}
-        parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)
-        self.compare_datasets(expected_dataset, parsed_dataset)
-
-    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
-    def test_can_save_without_creating_annotation_file_and_load(self, test_dir):
-        source_dataset = Dataset.from_iterable(
-            [
-                DatasetItem(
-                    id=1,
-                    subset="train",
-                    media=Image(data=np.ones((8, 8, 3))),
-                    annotations=[
-                        # Mask annotation is not supported by yolo8 formats, so should be omitted
-                        Mask(np.array([[0, 1, 1, 1, 0]]), label=0),
-                    ],
-                )
-            ],
-            categories=["label_" + str(i) for i in range(5)],
-        )
-        expected_dataset = Dataset.from_iterable(
-            [
-                DatasetItem(
-                    id=1,
-                    subset="train",
-                    media=Image(data=np.ones((8, 8, 3))),
-                )
-            ],
-            categories=[],
-        )
-        self.CONVERTER.convert(source_dataset, test_dir, save_media=True)
-        assert os.listdir(osp.join(test_dir, "labels", "train")) == []
         parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)
         self.compare_datasets(expected_dataset, parsed_dataset)
 

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -18,6 +18,7 @@ from datumaro.components.annotation import (
     AnnotationType,
     Bbox,
     LabelCategories,
+    Mask,
     Points,
     PointsCategories,
     Polygon,
@@ -466,14 +467,26 @@ class YOLOv8DetectionConverterTest(YoloConverterTest):
 
         self.compare_datasets(source_dataset, parsed_dataset)
 
-    @mark_requirement(Requirements.DATUM_609)
-    def test_can_save_and_load_without_annotations(self, test_dir):
-        source_dataset = self._generate_random_dataset([{"annotations": 0}])
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_without_creating_annotation_file_and_load(self, test_dir):
+        source_dataset = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id=1,
+                    subset="train",
+                    media=Image(data=np.ones((8, 8, 3))),
+                    annotations=[
+                        # Mask annotation is not supported by yolo8 formats, so should be omitted
+                        Mask(np.array([[0, 1, 1, 1, 0]]), label=0),
+                    ],
+                )
+            ],
+            categories=["label_" + str(i) for i in range(5)],
+        )
         self.CONVERTER.convert(source_dataset, test_dir, save_media=True)
 
         assert os.listdir(osp.join(test_dir, "labels", "train")) == []
-        parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)
-        self.compare_datasets(source_dataset, parsed_dataset)
+        Dataset.import_from(test_dir, self.IMPORTER.NAME)
 
     def _check_inplace_save_writes_only_updated_data(self, test_dir, expected):
         assert set(os.listdir(osp.join(test_dir, "images", "train"))) == {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- ignoring point order in skeleton annotations when comparing annotations
- do not create empty annotation files in yolo8

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced annotation comparison logic for skeleton annotations.
	- Introduced a method for saving YOLO annotations to improve code modularity.
  
- **Bug Fixes**
	- Improved robustness in annotation export for empty YOLO annotations.
  
- **Tests**
	- Added a test case specifically for comparing skeleton annotations.
	- Updated tests to ensure no annotation files are created when saving datasets with unsupported annotations.
  
- **Documentation**
	- Improved type safety and clarity in function signatures across various components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->