### PR TITLE
ultralytics yolo support for tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/50>)
 - Support for Ultralytics YOLO Classification format
   (<https://github.com/cvat-ai/datumaro/pull/59>)
+- Support for tracks in Ultralytics YOLO formats
+  (<https://github.com/cvat-ai/datumaro/pull/70>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels

--- a/src/datumaro/plugins/yolo_format/converter.py
+++ b/src/datumaro/plugins/yolo_format/converter.py
@@ -347,7 +347,7 @@ class YoloUltralyticsDetectionConverter(YoloConverter):
     def _make_annotation_line(self, width: int, height: int, anno: Annotation) -> Optional[str]:
         anno_line = super()._make_annotation_line(width=width, height=height, anno=anno)
 
-        if anno_line and {track_id_suffix := self._make_track_id_suffix(anno)}:
+        if anno_line and (track_id_suffix := self._make_track_id_suffix(anno)):
             anno_line = f"{anno_line.strip()}{track_id_suffix}\n"
 
         return anno_line

--- a/src/datumaro/plugins/yolo_format/converter.py
+++ b/src/datumaro/plugins/yolo_format/converter.py
@@ -340,9 +340,12 @@ class YoloUltralyticsDetectionConverter(YoloConverter):
     def _make_annotation_subset_folder(save_dir: str, subset: str) -> str:
         return osp.join(save_dir, YoloUltralyticsPath.LABELS_FOLDER_NAME, subset)
 
-    def _make_track_id_suffix(self, anno: Annotation):
+    def _make_track_id_suffix(self, anno: Annotation) -> str:
         track_id = anno.attributes.get("track_id") if self._write_track_id else None
-        return f" {track_id}" if track_id is not None else ""
+        try:
+            return f" {int(track_id)}"
+        except (ValueError, TypeError):
+            return ""
 
     def _make_annotation_line(self, width: int, height: int, anno: Annotation) -> Optional[str]:
         anno_line = super()._make_annotation_line(width=width, height=height, anno=anno)

--- a/src/datumaro/plugins/yolo_format/converter.py
+++ b/src/datumaro/plugins/yolo_format/converter.py
@@ -287,10 +287,12 @@ class YoloUltralyticsDetectionConverter(YoloConverter):
         save_dir: str,
         *,
         add_path_prefix: bool = True,
-        config_file=None,
+        config_file: str | None = None,
+        write_track_id: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(extractor, save_dir, add_path_prefix=add_path_prefix, **kwargs)
+        self._write_track_id = write_track_id
         self._config_filename = config_file or YoloUltralyticsPath.DEFAULT_CONFIG_FILE
 
     def _save_annotation_file(self, annotation_path, yolo_annotation):
@@ -305,6 +307,12 @@ class YoloUltralyticsDetectionConverter(YoloConverter):
             default=YoloUltralyticsPath.DEFAULT_CONFIG_FILE,
             type=str,
             help="config file name (default: %(default)s)",
+        )
+        parser.add_argument(
+            "--write-track-id",
+            default=False,
+            type=str_to_bool,
+            help="save track id to annotations",
         )
         return parser
 
@@ -332,6 +340,18 @@ class YoloUltralyticsDetectionConverter(YoloConverter):
     def _make_annotation_subset_folder(save_dir: str, subset: str) -> str:
         return osp.join(save_dir, YoloUltralyticsPath.LABELS_FOLDER_NAME, subset)
 
+    def _make_track_id_suffix(self, anno: Annotation):
+        track_id = anno.attributes.get("track_id") if self._write_track_id else None
+        return f" {track_id}" if track_id is not None else ""
+
+    def _make_annotation_line(self, width: int, height: int, anno: Annotation) -> Optional[str]:
+        anno_line = super()._make_annotation_line(width=width, height=height, anno=anno)
+
+        if anno_line and {track_id_suffix := self._make_track_id_suffix(anno)}:
+            anno_line = f"{anno_line.strip()}{track_id_suffix}\n"
+
+        return anno_line
+
 
 class YoloUltralyticsSegmentationConverter(YoloUltralyticsDetectionConverter):
     def _make_annotation_line(self, width: int, height: int, anno: Annotation) -> Optional[str]:
@@ -339,7 +359,7 @@ class YoloUltralyticsSegmentationConverter(YoloUltralyticsDetectionConverter):
             return
         values = [value / size for value, size in zip(anno.points, cycle((width, height)))]
         string_values = " ".join("%.6f" % p for p in values)
-        return "%s %s\n" % (self._map_labels_for_save[anno.label], string_values)
+        return f"{self._map_labels_for_save[anno.label]} {string_values}{self._make_track_id_suffix(anno)}\n"
 
 
 class YoloUltralyticsOrientedBoxesConverter(YoloUltralyticsDetectionConverter):
@@ -349,7 +369,7 @@ class YoloUltralyticsOrientedBoxesConverter(YoloUltralyticsDetectionConverter):
         points = _bbox_annotation_as_polygon(anno)
         values = [value / size for value, size in zip(points, cycle((width, height)))]
         string_values = " ".join("%.6f" % p for p in values)
-        return "%s %s\n" % (self._map_labels_for_save[anno.label], string_values)
+        return f"{self._map_labels_for_save[anno.label]} {string_values}{self._make_track_id_suffix(anno)}\n"
 
 
 class YoloUltralyticsPoseConverter(YoloUltralyticsDetectionConverter):
@@ -400,7 +420,10 @@ class YoloUltralyticsPoseConverter(YoloUltralyticsDetectionConverter):
             y = element.points[1] / height
             points_values[position] = f"{x:.6f} {y:.6f} {element.visibility[0].value}"
 
-        return f"{self._map_labels_for_save[skeleton.label]} {bbox_string_values} {' '.join(points_values)}\n"
+        return (
+            f"{self._map_labels_for_save[skeleton.label]} {bbox_string_values} "
+            f"{' '.join(points_values)}{self._make_track_id_suffix(skeleton)}\n"
+        )
 
 
 class YoloUltralyticsClassificationConverter(Converter):

--- a/src/datumaro/plugins/yolo_format/converter.py
+++ b/src/datumaro/plugins/yolo_format/converter.py
@@ -287,7 +287,7 @@ class YoloUltralyticsDetectionConverter(YoloConverter):
         save_dir: str,
         *,
         add_path_prefix: bool = True,
-        config_file: str | None = None,
+        config_file: Optional[str] = None,
         write_track_id: bool = False,
         **kwargs,
     ) -> None:

--- a/src/datumaro/plugins/yolo_format/extractor.py
+++ b/src/datumaro/plugins/yolo_format/extractor.py
@@ -527,7 +527,7 @@ class YoloUltralyticsOrientedBoxesExtractor(YoloUltralyticsDetectionExtractor):
         if len(parts) not in [9, 10]:
             raise InvalidAnnotationError(
                 f"Unexpected field count {len(parts)} in the bbox description. "
-                "Expected 9 fields (label, x1, y1, x2, y2, x3, y3, x4, y4)."
+                "Expected 9 or 10 fields (label, x1, y1, x2, y2, x3, y3, x4, y4 [, track_id])."
             )
         label_id = self._map_label_id(parts[0])
         points = [

--- a/src/datumaro/plugins/yolo_format/extractor.py
+++ b/src/datumaro/plugins/yolo_format/extractor.py
@@ -472,6 +472,19 @@ class YoloUltralyticsDetectionExtractor(YoloExtractor):
         else:
             yield from subset_images_source
 
+    def _load_one_annotation(
+        self, parts: List[str], image_height: int, image_width: int
+    ) -> Annotation:
+        if len(parts) not in [5, 6]:
+            raise InvalidAnnotationError(
+                f"Unexpected field count {len(parts)} in the bbox description. "
+                "Expected 5 or 6 fields (label, xc, yc, w, h, <optional track id>)."
+            )
+        bbox = super()._load_one_annotation(parts[:5], image_height, image_width)
+        if len(parts) == 6:
+            bbox.attributes["track_id"] = self._parse_field(parts[-1], int, "bbox track id")
+        return bbox
+
 
 class YoloUltralyticsSegmentationExtractor(YoloUltralyticsDetectionExtractor):
     def _load_segmentation_annotation(
@@ -479,24 +492,31 @@ class YoloUltralyticsSegmentationExtractor(YoloUltralyticsDetectionExtractor):
     ) -> Polygon:
         label_id = self._map_label_id(parts[0])
         points = [
-            self._parse_field(
-                value, float, f"polygon point {idx // 2} {'x' if idx % 2 == 0 else 'y'}"
+            parsed_value
+            for idx, (x, y) in enumerate(
+                take_by(parts[1:] if len(parts) % 2 == 1 else parts[1:-1], 2)
             )
-            for idx, value in enumerate(parts[1:])
+            for parsed_value in [
+                self._parse_field(x, float, f"polygon point {idx} x"),
+                self._parse_field(y, float, f"polygon point {idx} y"),
+            ]
         ]
         scaled_points = [
             value * size for value, size in zip(points, cycle((image_width, image_height)))
         ]
-        return Polygon(scaled_points, label=label_id)
+        polygon = Polygon(scaled_points, label=label_id)
+        if len(parts) % 2 == 0:
+            polygon.attributes["track_id"] = self._parse_field(parts[-1], int, "polygon track id")
+        return polygon
 
     def _load_one_annotation(
         self, parts: List[str], image_height: int, image_width: int
     ) -> Annotation:
-        if len(parts) > 5 and len(parts) % 2 == 1:
+        if len(parts) > 6:
             return self._load_segmentation_annotation(parts, image_height, image_width)
         raise InvalidAnnotationError(
             f"Unexpected field count {len(parts)} in the polygon description. "
-            "Expected odd number > 5 of fields for segment annotation (label, x1, y1, x2, y2, x3, y3, ...)"
+            "Expected fields for segment annotation: (label, x1, y1, x2, y2, x3, y3, ..., <optional track id>)"
         )
 
 
@@ -504,7 +524,7 @@ class YoloUltralyticsOrientedBoxesExtractor(YoloUltralyticsDetectionExtractor):
     def _load_one_annotation(
         self, parts: List[str], image_height: int, image_width: int
     ) -> Annotation:
-        if len(parts) != 9:
+        if len(parts) not in [9, 10]:
             raise InvalidAnnotationError(
                 f"Unexpected field count {len(parts)} in the bbox description. "
                 "Expected 9 fields (label, x1, y1, x2, y2, x3, y3, x4, y4)."
@@ -515,7 +535,9 @@ class YoloUltralyticsOrientedBoxesExtractor(YoloUltralyticsDetectionExtractor):
                 self._parse_field(x, float, f"bbox point {idx} x") * image_width,
                 self._parse_field(y, float, f"bbox point {idx} y") * image_height,
             )
-            for idx, (x, y) in enumerate(take_by(parts[1:], 2))
+            for idx, (x, y) in enumerate(
+                take_by(parts[1:] if len(parts) % 2 == 1 else parts[1:-1], 2)
+            )
         ]
 
         (center_x, center_y), (width, height), rotation = cv2.minAreaRect(
@@ -523,7 +545,7 @@ class YoloUltralyticsOrientedBoxesExtractor(YoloUltralyticsDetectionExtractor):
         )
         rotation = rotation % 180
 
-        return Bbox(
+        bbox = Bbox(
             x=center_x - width / 2,
             y=center_y - height / 2,
             w=width,
@@ -531,6 +553,9 @@ class YoloUltralyticsOrientedBoxesExtractor(YoloUltralyticsDetectionExtractor):
             label=label_id,
             attributes=(dict(rotation=rotation) if abs(rotation) > 0.00001 else {}),
         )
+        if len(parts) == 10:
+            bbox.attributes["track_id"] = self._parse_field(parts[-1], int, "bbox track id")
+        return bbox
 
 
 class YoloUltralyticsPoseExtractor(YoloUltralyticsDetectionExtractor):
@@ -646,11 +671,12 @@ class YoloUltralyticsPoseExtractor(YoloUltralyticsDetectionExtractor):
         self, parts: List[str], image_height: int, image_width: int
     ) -> Annotation:
         max_number_of_points, values_per_point = self._kpt_shape
-        if len(parts) != 5 + max_number_of_points * values_per_point:
+        if len(parts) - (5 + max_number_of_points * values_per_point) not in [0, 1]:
             raise InvalidAnnotationError(
                 f"Unexpected field count {len(parts)} in the skeleton description. "
-                "Expected 5 fields (label, xc, yc, w, h)"
-                f"and then {values_per_point} for each of {max_number_of_points} points"
+                "Expected 5 fields (label, xc, yc, w, h) "
+                f"and then {values_per_point} for each of {max_number_of_points} points "
+                "and then optional track id"
             )
 
         label_id = self._map_label_id(parts[0])
@@ -694,7 +720,10 @@ class YoloUltralyticsPoseExtractor(YoloUltralyticsDetectionExtractor):
                 ),
             ]
         ]
-        return Skeleton(points, label=label_id)
+        skeleton = Skeleton(points, label=label_id)
+        if len(parts) - (5 + max_number_of_points * values_per_point) == 1:
+            skeleton.attributes["track_id"] = self._parse_field(parts[-1], int, "skeleton track id")
+        return skeleton
 
 
 class YoloUltralyticsClassificationExtractor(YoloBaseExtractor):

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -570,6 +570,41 @@ class YoloUltralyticsDetectionConverterTest(YoloConverterTest):
         parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)
         self.compare_datasets(expected_dataset, parsed_dataset)
 
+    @pytest.mark.parametrize("write_track_id", [True, False])
+    def test_write_track_id_parameter(self, test_dir, write_track_id):
+        dataset_without_tracks = self._generate_random_dataset(
+            recipes=[{"annotations": 2}, {"annotations": 3}]
+        )
+        items = list(dataset_without_tracks)
+        dataset_with_track = Dataset.from_iterable(
+            [
+                items[0].wrap(
+                    annotations=[
+                        items[0]
+                        .annotations[0]
+                        .wrap(
+                            attributes=dict(items[0].annotations[0].attributes, track_id=77),
+                        ),
+                        items[0].annotations[1],
+                    ]
+                ),
+                items[1],
+            ],
+            categories=dataset_without_tracks.categories(),
+        )
+
+        expected_dataset = dataset_with_track if write_track_id else dataset_without_tracks
+        self.CONVERTER.convert(
+            dataset_with_track, test_dir, save_media=True, write_track_id=write_track_id
+        )
+
+        if write_track_id:
+            with open(osp.join(test_dir, "labels", "train", "1.txt"), "r") as f:
+                assert f.readlines()[0].strip().endswith(" 77")
+
+        parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)
+        self.compare_datasets(expected_dataset, parsed_dataset)
+
 
 class YoloUltralyticsSegmentationConverterTest(YoloUltralyticsDetectionConverterTest):
     CONVERTER = YoloUltralyticsSegmentationConverter

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -1259,6 +1259,29 @@ class YoloUltralyticsDetectionImporterTest(YoloImporterTest):
         dataset = Dataset.import_from(dataset_path, self.IMPORTER.NAME)
         self.compare_datasets(expected_dataset, dataset)
 
+    def test_can_import_with_track_id(self, test_dir):
+        track_id = 4
+
+        expected_dataset = self._asset_dataset()
+        untracked_anno = list(expected_dataset)[0].annotations[0]
+        tracked_anno = untracked_anno.wrap(
+            attributes=dict(untracked_anno.attributes, track_id=track_id)
+        )
+        for item in expected_dataset:
+            item.annotations.append(tracked_anno)
+
+        dataset_path = osp.join(test_dir, "dataset")
+        shutil.copytree(get_test_asset_path("yolo_dataset", self.ASSETS[0]), dataset_path)
+
+        labels_path = osp.join(dataset_path, "labels", "train", "1.txt")
+        with open(labels_path, "r") as f:
+            first_line = f.readline().strip()
+        with open(labels_path, "a") as f:
+            f.write(f"{first_line} {track_id}")
+
+        dataset = Dataset.import_from(dataset_path, self.IMPORTER.NAME)
+        self.compare_datasets(expected_dataset, dataset)
+
 
 class YoloUltralyticsSegmentationImporterTest(YoloUltralyticsDetectionImporterTest):
     IMPORTER = YoloUltralyticsSegmentationImporter
@@ -1524,6 +1547,9 @@ class YoloExtractorTest:
         self._prepare_dataset(test_dir)
         with open(osp.join(test_dir, self._get_annotation_dir(), "a.txt"), "w") as f:
             values = [0] + self._make_some_annotation_values()
+            assert field <= len(values)
+            if field == len(values):
+                values.append(None)
             values[field] = "a"
             f.write(" ".join(str(v) for v in values))
 
@@ -1594,6 +1620,20 @@ class YoloUltralyticsDetectionExtractorTest(YoloExtractorTest):
         source_dataset.get("a", subset="train").annotations.clear()
         compare_datasets(helper_tc, source_dataset, actual)
 
+    @mark_requirement(Requirements.DATUM_ERROR_REPORTING)
+    @pytest.mark.parametrize(
+        "field, field_name",
+        [
+            (1, "bbox center x"),
+            (2, "bbox center y"),
+            (3, "bbox width"),
+            (4, "bbox height"),
+            (5, "bbox track id"),
+        ],
+    )
+    def test_can_report_invalid_field_type(self, field, field_name, test_dir):
+        self._check_can_report_invalid_field_type(field, field_name, test_dir)
+
 
 class YoloUltralyticsSegmentationExtractorTest(YoloUltralyticsDetectionExtractorTest):
     IMPORTER = YoloUltralyticsSegmentationImporter
@@ -1618,6 +1658,7 @@ class YoloUltralyticsSegmentationExtractorTest(YoloUltralyticsDetectionExtractor
             (4, "polygon point 1 y"),
             (5, "polygon point 2 x"),
             (6, "polygon point 2 y"),
+            (7, "polygon track id"),
         ],
     )
     def test_can_report_invalid_field_type(self, field, field_name, test_dir):
@@ -1654,6 +1695,7 @@ class YoloUltralyticsOrientedBoxesExtractorTest(YoloUltralyticsDetectionExtracto
             (4, "bbox point 1 y"),
             (5, "bbox point 2 x"),
             (6, "bbox point 2 y"),
+            (9, "bbox track id"),
         ],
     )
     def test_can_report_invalid_field_type(self, field, field_name, test_dir):
@@ -1771,6 +1813,7 @@ class YoloUltralyticsPoseExtractorTest(YoloUltralyticsDetectionExtractorTest):
             (8, "skeleton point 1 x"),
             (9, "skeleton point 1 y"),
             (10, "skeleton point 1 visibility"),
+            (17, "skeleton track id"),
         ],
     )
     def test_can_report_invalid_field_type(self, field, field_name, test_dir):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
https://github.com/cvat-ai/cvat/issues/8645
Adding support for tracks for Ultralytics YOLO formats. All of them can now import annotations with track_id present, and have an option to export with track_id

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for optional track IDs in YOLO format annotations.
  - Introduced a command line option to control the inclusion of track IDs during export.

- **Bug Fixes**
  - Enhanced error handling for invalid annotation fields related to track IDs.

- **Tests**
  - Added tests to verify functionality for track ID handling in both conversion and import processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->