### PR TITLE
yolo: if train subset already present, merge default subset into it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/50>)
 - Support for Ultralytics YOLO Classification format
   (<https://github.com/cvat-ai/datumaro/pull/59>)
+- YOLO formats now merge default subset and train subset if both are present
+  (<https://github.com/cvat-ai/datumaro/pull/71>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels

--- a/src/datumaro/plugins/yolo_format/converter.py
+++ b/src/datumaro/plugins/yolo_format/converter.py
@@ -73,10 +73,10 @@ def _bbox_annotation_as_polygon(bbox: Bbox) -> List[float]:
     return points
 
 
-def _resolve_subsets(initial_subsets: dict[str, IExtractor]) -> dict[str, Iterable]:
+def _resolve_subsets(initial_subsets: Dict[str, IExtractor]) -> Dict[str, Iterable]:
     assert YoloPath.DEFAULT_SUBSET_NAME.lower() != DEFAULT_SUBSET_NAME.lower()
 
-    subsets: dict[str, Iterable] = {
+    subsets: Dict[str, Iterable] = {
         subset_name: subset
         for subset_name, subset in initial_subsets.items()
         if subset_name and subset_name != DEFAULT_SUBSET_NAME

--- a/src/datumaro/plugins/yolo_format/converter.py
+++ b/src/datumaro/plugins/yolo_format/converter.py
@@ -11,7 +11,7 @@ import os.path as osp
 from collections import OrderedDict, defaultdict
 from functools import cached_property
 from itertools import cycle
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 import yaml
 
@@ -73,6 +73,26 @@ def _bbox_annotation_as_polygon(bbox: Bbox) -> List[float]:
     return points
 
 
+def _resolve_subsets(initial_subsets: dict[str, IExtractor]) -> dict[str, Iterable]:
+    assert YoloPath.DEFAULT_SUBSET_NAME.lower() != DEFAULT_SUBSET_NAME.lower()
+
+    subsets: dict[str, Iterable] = {
+        subset_name: subset
+        for subset_name, subset in initial_subsets.items()
+        if subset_name and subset_name != DEFAULT_SUBSET_NAME
+    }
+    for subset_name, subset in initial_subsets.items():
+        if not subset_name or subset_name == DEFAULT_SUBSET_NAME:
+            subset_name = YoloPath.DEFAULT_SUBSET_NAME
+            try:
+                subset_name = next(name for name in subsets if name.lower() == subset_name.lower())
+            except StopIteration:
+                pass
+            subsets[subset_name] = itertools.chain(subsets.get(subset_name, []), subset)
+
+    return subsets
+
+
 class YoloConverter(Converter):
     # https://github.com/AlexeyAB/darknet#how-to-train-to-detect-your-custom-objects
     DEFAULT_IMAGE_EXT = ".jpg"
@@ -109,12 +129,11 @@ class YoloConverter(Converter):
 
         subset_lists = OrderedDict()
 
-        subsets = self._extractor.subsets()
+        subsets = _resolve_subsets(self._extractor.subsets())
+
         pbars = self._ctx.progress_reporter.split(len(subsets))
         for (subset_name, subset), pbar in zip(subsets.items(), pbars):
-            if not subset_name or subset_name == DEFAULT_SUBSET_NAME:
-                subset_name = YoloPath.DEFAULT_SUBSET_NAME
-            elif subset_name in self.RESERVED_CONFIG_KEYS:
+            if subset_name in self.RESERVED_CONFIG_KEYS:
                 raise DatasetExportError(
                     f"Can't export '{subset_name}' subset in YOLO format, this word is reserved."
                 )
@@ -420,12 +439,9 @@ class YoloUltralyticsClassificationConverter(Converter):
 
         labels = self._extractor.categories()[AnnotationType.label]
 
-        subsets = self._extractor.subsets()
+        subsets = _resolve_subsets(self._extractor.subsets())
         pbars = self._ctx.progress_reporter.split(len(subsets))
         for (subset_name, subset), pbar in zip(subsets.items(), pbars):
-            if not subset_name or subset_name == DEFAULT_SUBSET_NAME:
-                subset_name = YoloPath.DEFAULT_SUBSET_NAME
-
             os.makedirs(osp.join(self._save_dir, subset_name), exist_ok=True)
 
             items_info = defaultdict(dict)

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -36,7 +36,7 @@ from datumaro.components.errors import (
     ItemImportError,
     UndeclaredLabelError,
 )
-from datumaro.components.extractor import DatasetItem
+from datumaro.components.extractor import DEFAULT_SUBSET_NAME, DatasetItem
 from datumaro.components.format_detection import FormatDetectionContext, FormatRequirementsUnmet
 from datumaro.components.media import Image
 from datumaro.plugins.yolo_format.converter import (
@@ -184,6 +184,23 @@ class YoloConverterTest(CompareDatasetMixin):
         parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)
 
         self.compare_datasets(source_dataset, parsed_dataset)
+
+    def test_merges_default_subset_to_train_if_exists(self, test_dir):
+        source_dataset = self._generate_random_dataset(
+            [
+                {"subset": DEFAULT_SUBSET_NAME},
+                {"subset": "Train"},
+            ]
+        )
+        expected_dataset = source_dataset.from_iterable(
+            [item.wrap(subset="Train") for item in source_dataset],
+            categories=source_dataset.categories(),
+        )
+
+        self.CONVERTER.convert(source_dataset, test_dir, save_media=True)
+        parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)
+
+        self.compare_datasets(expected_dataset, parsed_dataset)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_dataset_with_image_info(self, test_dir):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
YOLO formats export "default" subset and subset without name as "train".
It causes problems if "train" or "Train" subset is also present.
Fixing it by merging subsets.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for improved handling of subsets in YOLO format converters.
- **Bug Fixes**
	- Enhanced error handling and logging during the export process.
- **Tests**
	- Added a test to verify merging of default subsets into the "Train" subset during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->