### PR TITLE
always keeping exif info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/71>)
 - Support for tracks in Ultralytics YOLO formats
   (<https://github.com/cvat-ai/datumaro/pull/70>)
-- Support for tracks in Ultralytics YOLO formats
-  (<https://github.com/cvat-ai/datumaro/pull/70>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels
@@ -79,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `segment_iou()`, added a separate function argument
   (turned off by default)
   (<https://github.com/cvat-ai/datumaro/pull/41>)
+- Always use exif orientation info when loading images
+  (<https://github.com/cvat-ai/datumaro/pull/82>)
 
 ### Deprecated
 - `--save-images` is replaced with `--save-media` in CLI and converter API
@@ -111,8 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/41>)
 - `Dataset.get()` could ignore existing transforms in the dataset
   (<https://github.com/cvat-ai/datumaro/pull/45>)
-- Always use exif orientation info when loading images
-  (<https://github.com/cvat-ai/datumaro/pull/82>)
+- Failing `resize` transform for RLE masks
+  (<https://github.com/cvat-ai/datumaro/pull/46>)
 
 ### Security
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/71>)
 - Support for tracks in Ultralytics YOLO formats
   (<https://github.com/cvat-ai/datumaro/pull/70>)
+- Support for tracks in Ultralytics YOLO formats
+  (<https://github.com/cvat-ai/datumaro/pull/70>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels
@@ -109,8 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/41>)
 - `Dataset.get()` could ignore existing transforms in the dataset
   (<https://github.com/cvat-ai/datumaro/pull/45>)
-- Failing `resize` transform for RLE masks
-  (<https://github.com/cvat-ai/datumaro/pull/46>)
+- Always use exif orientation info when loading images
+  (<https://github.com/cvat-ai/datumaro/pull/82>)
 
 ### Security
 - TBD

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ def parse_requirements(filename=CORE_REQUIREMENTS_FILE):
 
 CORE_REQUIREMENTS = parse_requirements(CORE_REQUIREMENTS_FILE)
 if strtobool(os.getenv("DATUMARO_HEADLESS", "0").lower()):
-    CORE_REQUIREMENTS.append("opencv-python-headless")
+    CORE_REQUIREMENTS.append("opencv-python-headless<4.11")
 else:
-    CORE_REQUIREMENTS.append("opencv-python")
+    CORE_REQUIREMENTS.append("opencv-python<4.11")
 
 DEFAULT_REQUIREMENTS = parse_requirements(DEFAULT_REQUIREMENTS_FILE)
 

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -39,7 +39,6 @@ from datumaro.util.image import (
     DEFAULT_IMAGE_META_FILE_NAME,
     ImageMeta,
     find_images,
-    load_image,
     load_image_meta_file,
 )
 from datumaro.util.meta_file_util import get_meta_file, has_meta_file, parse_meta_file
@@ -108,10 +107,6 @@ class _YoloBase(SubsetBase):
             subset.items = self._get_lazy_subset_items(subset_name)
             self._subsets[subset_name] = subset
 
-    @classmethod
-    def _image_loader(cls, *args, **kwargs):
-        return load_image(*args, **kwargs, keep_exif=True)
-
     def _get(self, item_id: str, subset_name: str) -> Optional[DatasetItem]:
         subset = self._subsets[subset_name]
         item = subset.items[item_id]
@@ -121,10 +116,7 @@ class _YoloBase(SubsetBase):
                 image_size = self._image_info.get(item_id)
                 image_path = osp.join(self._path, item)
 
-                if image_size:
-                    image = Image(path=image_path, size=image_size)
-                else:
-                    image = Image(path=image_path, data=self._image_loader)
+                image = Image(path=image_path, size=image_size)
 
                 annotations = self._parse_annotations(image, item_id=(item_id, subset_name))
 

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -70,17 +70,13 @@ def load_image(path: str, dtype: DTypeLike = np.float32, **kwargs):
         with open(path, "rb") as f:
             image_bytes = f.read()
 
-        if kwargs.get("keep_exif"):
-            return decode_image(image_bytes, dtype=dtype, cv2_read_flag=1)
-
         return decode_image(image_bytes, dtype=dtype)
     elif _IMAGE_BACKEND == _IMAGE_BACKENDS.PIL:
         from PIL import Image, ImageOps
 
         image = Image.open(path)
 
-        if kwargs.get("keep_exif"):
-            image = ImageOps.exif_transpose(image)
+        image = ImageOps.exif_transpose(image)
 
         image = np.asarray(image, dtype=dtype)
         if len(image.shape) == 3 and image.shape[2] in {3, 4}:
@@ -189,7 +185,7 @@ def decode_image(image_bytes: bytes, dtype: DTypeLike = np.float32, **kwargs) ->
         import cv2
 
         image = np.frombuffer(image_bytes, dtype=np.uint8)
-        image = cv2.imdecode(image, kwargs.get("cv2_read_flag", cv2.IMREAD_UNCHANGED))
+        image = cv2.imdecode(image, cv2.IMREAD_UNCHANGED ^ cv2.IMREAD_IGNORE_ORIENTATION)
         image = image.astype(dtype)
     elif _IMAGE_BACKEND == _IMAGE_BACKENDS.PIL:
         from PIL import Image

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -3,9 +3,9 @@ from itertools import product
 from unittest import TestCase
 
 import numpy as np
+import PIL
 
 import datumaro.util.image as image_module
-import PIL
 
 from tests.requirements import Requirements, mark_requirement
 from tests.utils.test_utils import TestDir

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 import numpy as np
 
 import datumaro.util.image as image_module
+import PIL
 
 from tests.requirements import Requirements, mark_requirement
 from tests.utils.test_utils import TestDir
@@ -70,3 +71,19 @@ class ImageOperationsTest(TestCase):
             path = osp.join(test_dir, "some", "path.jpg")
             image_module.save_image(path, np.ones((5, 4, 3)), create_dir=True)
             self.assertTrue(osp.isfile(path))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_load_image_with_exif_info(self):
+        with TestDir() as test_dir:
+            image_path = osp.join(test_dir, "1.jpg")
+            image_module.save_image(image_path, np.ones((15, 10, 3)))
+
+            img = PIL.Image.open(image_path)
+            exif = img.getexif()
+            exif.update([(PIL.ExifTags.Base.Orientation, 6)])
+            img.save(image_path, exif=exif)
+
+            for load_backend in image_module._IMAGE_BACKENDS:
+                image_module._IMAGE_BACKEND = load_backend
+                img = image_module.load_image(image_path)
+                assert img.shape == (10, 15, 3)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Added support for EXIF image rotation in all image reads in all formats, not only for YOLO

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
