### PR TITLE
Restrict opencv version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ def parse_requirements(filename=CORE_REQUIREMENTS_FILE):
 
 CORE_REQUIREMENTS = parse_requirements(CORE_REQUIREMENTS_FILE)
 if strtobool(os.getenv("DATUMARO_HEADLESS", "0").lower()):
-    CORE_REQUIREMENTS.append("opencv-python-headless")
+    CORE_REQUIREMENTS.append("opencv-python-headless<4.11")
 else:
-    CORE_REQUIREMENTS.append("opencv-python")
+    CORE_REQUIREMENTS.append("opencv-python<4.11")
 
 DEFAULT_REQUIREMENTS = parse_requirements(DEFAULT_REQUIREMENTS_FILE)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Dependency for #82 

OpenCV added RGB mode for image reading in 4.11. This PR is a temporary workaround, the full solution is to be tracked in #83. Need to add conditional logic for opencv versions before and after 4.11 in cases where `cv2.IMREAD_UNCHANGED` is used together with `cv2.IMREAD_IGNORE_ORIENTATION`.

- Restricted OpenCV version to avoid occasional image API changes

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
