### PR TITLE
Support OpenCV >=4.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ def parse_requirements(filename=CORE_REQUIREMENTS_FILE):
 
 CORE_REQUIREMENTS = parse_requirements(CORE_REQUIREMENTS_FILE)
 if strtobool(os.getenv("DATUMARO_HEADLESS", "0").lower()):
-    CORE_REQUIREMENTS.append("opencv-python-headless<4.11")
+    CORE_REQUIREMENTS.append("opencv-python-headless")
 else:
-    CORE_REQUIREMENTS.append("opencv-python<4.11")
+    CORE_REQUIREMENTS.append("opencv-python")
 
 DEFAULT_REQUIREMENTS = parse_requirements(DEFAULT_REQUIREMENTS_FILE)
 

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -67,6 +67,7 @@ class ImageColorChannel(Enum):
         """Convert image color channel for OpenCV image (np.ndarray)."""
         image_buffer = np.frombuffer(image_bytes, dtype=dtype)
 
+        # OpenCV 4.11 added the new imread flag, so we will use it if available
         IMREAD_COLOR_RGB = getattr(cv2, "IMREAD_COLOR_RGB", 0)
 
         if self == ImageColorChannel.UNCHANGED:

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -67,8 +67,19 @@ class ImageColorChannel(Enum):
         """Convert image color channel for OpenCV image (np.ndarray)."""
         image_buffer = np.frombuffer(image_bytes, dtype=dtype)
 
+        try:
+            from cv2 import IMREAD_COLOR_RGB
+        except ImportError:
+            IMREAD_COLOR_RGB = 0
+
         if self == ImageColorChannel.UNCHANGED:
-            return cv2.imdecode(image_buffer, cv2.IMREAD_UNCHANGED ^ cv2.IMREAD_IGNORE_ORIENTATION)
+            return cv2.imdecode(
+                image_buffer,
+                cv2.IMREAD_UNCHANGED ^ cv2.IMREAD_IGNORE_ORIENTATION ^ IMREAD_COLOR_RGB,
+            )
+
+        if IMREAD_COLOR_RGB and self == ImageColorChannel.COLOR_RGB:
+            return cv2.imdecode(image_buffer, IMREAD_COLOR_RGB)
 
         img = cv2.imdecode(image_buffer, cv2.IMREAD_COLOR)
 

--- a/src/datumaro/util/image.py
+++ b/src/datumaro/util/image.py
@@ -67,10 +67,7 @@ class ImageColorChannel(Enum):
         """Convert image color channel for OpenCV image (np.ndarray)."""
         image_buffer = np.frombuffer(image_bytes, dtype=dtype)
 
-        try:
-            from cv2 import IMREAD_COLOR_RGB
-        except ImportError:
-            IMREAD_COLOR_RGB = 0
+        IMREAD_COLOR_RGB = getattr(cv2, "IMREAD_COLOR_RGB", 0)
 
         if self == ImageColorChannel.UNCHANGED:
             return cv2.imdecode(

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -17,6 +17,11 @@ from ..requirements import Requirements, mark_requirement
 from tests.utils.test_utils import TestDir
 
 
+def generate_test_img(channels: int) -> np.ndarray:
+    size = (5, 4, channels) if channels > 1 else (5, 4)
+    return np.random.randint(low=0, high=256, size=size, dtype=np.uint8)
+
+
 class ImageOperationsTest(TestCase):
     def setUp(self):
         self.default_backend = image_module.IMAGE_BACKEND.get()
@@ -29,10 +34,7 @@ class ImageOperationsTest(TestCase):
         backends = image_module.ImageBackend
         for save_backend, load_backend, c in product(backends, backends, [1, 3]):
             with TestDir() as test_dir:
-                if c == 1:
-                    src_image = np.random.randint(0, 255 + 1, (2, 4))
-                else:
-                    src_image = np.random.randint(0, 255 + 1, (2, 4, c))
+                src_image = generate_test_img(c)
                 path = osp.join(test_dir, "img.png")  # lossless
 
                 image_module.IMAGE_BACKEND.set(save_backend)
@@ -60,10 +62,7 @@ class ImageOperationsTest(TestCase):
     def test_encode_and_decode_backends(self):
         backends = image_module.ImageBackend
         for save_backend, load_backend, c in product(backends, backends, [1, 3]):
-            if c == 1:
-                src_image = np.random.randint(0, 255 + 1, (2, 4))
-            else:
-                src_image = np.random.randint(0, 255 + 1, (2, 4, c))
+            src_image = generate_test_img(c)
 
             image_module.IMAGE_BACKEND.set(save_backend)
             buffer = image_module.encode_image(src_image, ".png", jpeg_quality=100)  # lossless
@@ -116,20 +115,16 @@ class ImageOperationsTest(TestCase):
 
 
 class ImageDecodeTest:
-    def generate_test_img(self, channels) -> np.ndarray:
-        return np.random.randint(low=0, high=256, size=(5, 4, channels), dtype=np.uint8)
-
-    @pytest.mark.parametrize(
-        "image_backend", [image_module.ImageBackend.cv2, image_module.ImageBackend.PIL]
-    )
+    @pytest.mark.parametrize("image_backend", image_module.ImageBackend)
     @pytest.mark.parametrize("channels", [1, 3, 4])
     def test_decode_image_context(self, image_backend: image_module.ImageBackend, channels: int):
-        original_image = self.generate_test_img(channels)
+        original_image = generate_test_img(channels)
         img_bytes = image_module.encode_image(original_image, ".png")
 
-        expected_bgr_image = (
-            original_image[:, :, :3] if channels >= 3 else np.repeat(original_image, 3, axis=2)
-        )
+        if channels == 1:
+            expected_bgr_image = np.repeat(original_image[:, :, np.newaxis], 3, axis=2)
+        else:
+            expected_bgr_image = original_image[:, :, :3]
 
         # 3 channels from ImageColorScale.COLOR_BGR
         with image_module.decode_image_context(
@@ -152,9 +147,7 @@ class ImageDecodeTest:
             image_backend, image_module.ImageColorChannel.UNCHANGED
         ):
             img_decoded = image_module.decode_image(img_bytes)
-            if len(img_decoded.shape) == 2:
-                img_decoded = img_decoded[:, :, np.newaxis]
-            assert img_decoded.shape[-1] == channels
+            assert img_decoded.shape == original_image.shape
 
             if image_backend == image_module.ImageBackend.cv2 or channels == 1:
                 assert np.allclose(original_image, img_decoded)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -142,7 +142,7 @@ class ImageDecodeTest:
             assert img_decoded.shape[-1] == 3
             assert np.allclose(expected_bgr_image[:, :, ::-1], img_decoded)
 
-        # 4 channels from ImageColorScale.UNCHANGED
+        # 1 (without an extra dim), 3 or 4 channels from ImageColorScale.UNCHANGED
         with image_module.decode_image_context(
             image_backend, image_module.ImageColorChannel.UNCHANGED
         ):
@@ -152,7 +152,7 @@ class ImageDecodeTest:
             if image_backend == image_module.ImageBackend.cv2 or channels == 1:
                 assert np.allclose(original_image, img_decoded)
             else:
-                # PIL will return RGBA, thus we need to correct the fixture
+                # PIL will return RGB(A), thus we need to correct the fixture
                 to_rgb = original_image[:, :, :3][:, :, ::-1]
                 original_image[:, :, :3] = to_rgb
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -153,6 +153,6 @@ class ImageDecodeTest:
 
             if image_backend == image_module.ImageBackend.PIL and channels != 1:
                 # PIL returns RGB(A)
-                img_decoded[:, :, :3] = img_decoded[:, :, 2::-1] # to bgr
+                img_decoded[:, :, :3] = img_decoded[:, :, 2::-1]  # to bgr
 
             assert np.allclose(original_image, img_decoded)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -151,11 +151,8 @@ class ImageDecodeTest:
             img_decoded = image_module.decode_image(img_bytes)
             assert img_decoded.shape == original_image.shape
 
-            if image_backend == image_module.ImageBackend.cv2 or channels == 1:
-                assert np.allclose(original_image, img_decoded)
-            else:
-                # PIL will return RGB(A), thus we need to correct the fixture
-                to_rgb = original_image[:, :, :3][:, :, ::-1]
-                original_image[:, :, :3] = to_rgb
+            if image_backend == image_module.ImageBackend.PIL and channels != 1:
+                # PIL returns RGB(A)
+                img_decoded[:, :, :3] = img_decoded[:, :, 2::-1] # to bgr
 
-                assert np.allclose(original_image, img_decoded)
+            assert np.allclose(original_image, img_decoded)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -116,17 +116,20 @@ class ImageOperationsTest(TestCase):
 
 
 class ImageDecodeTest:
-    @pytest.fixture
-    def fxt_img_four_channels(self) -> np.ndarray:
-        return np.random.randint(low=0, high=256, size=(5, 4, 4), dtype=np.uint8)
+    def generate_test_img(self, channels) -> np.ndarray:
+        return np.random.randint(low=0, high=256, size=(5, 4, channels), dtype=np.uint8)
 
     @pytest.mark.parametrize(
         "image_backend", [image_module.ImageBackend.cv2, image_module.ImageBackend.PIL]
     )
-    def test_decode_image_context(
-        self, fxt_img_four_channels: np.ndarray, image_backend: image_module.ImageBackend
-    ):
-        img_bytes = image_module.encode_image(fxt_img_four_channels, ".png")
+    @pytest.mark.parametrize("channels", [1, 3, 4])
+    def test_decode_image_context(self, image_backend: image_module.ImageBackend, channels: int):
+        original_image = self.generate_test_img(channels)
+        img_bytes = image_module.encode_image(original_image, ".png")
+
+        expected_bgr_image = (
+            original_image[:, :, :3] if channels >= 3 else np.repeat(original_image, 3, axis=2)
+        )
 
         # 3 channels from ImageColorScale.COLOR_BGR
         with image_module.decode_image_context(
@@ -134,7 +137,7 @@ class ImageDecodeTest:
         ):
             img_decoded = image_module.decode_image(img_bytes)
             assert img_decoded.shape[-1] == 3
-            assert np.allclose(fxt_img_four_channels[:, :, :3], img_decoded)
+            assert np.allclose(expected_bgr_image, img_decoded)
 
         # 3 channels from ImageColorScale.COLOR_RGB
         with image_module.decode_image_context(
@@ -142,23 +145,22 @@ class ImageDecodeTest:
         ):
             img_decoded = image_module.decode_image(img_bytes)
             assert img_decoded.shape[-1] == 3
-            assert np.allclose(
-                fxt_img_four_channels[:, :, :3][:, :, ::-1],  # Flip color channels of the fixture
-                img_decoded,
-            )
+            assert np.allclose(expected_bgr_image[:, :, ::-1], img_decoded)
 
         # 4 channels from ImageColorScale.UNCHANGED
         with image_module.decode_image_context(
             image_backend, image_module.ImageColorChannel.UNCHANGED
         ):
             img_decoded = image_module.decode_image(img_bytes)
-            assert img_decoded.shape[-1] == 4
+            if len(img_decoded.shape) == 2:
+                img_decoded = img_decoded[:, :, np.newaxis]
+            assert img_decoded.shape[-1] == channels
 
-            if image_backend == image_module.ImageBackend.cv2:
-                assert np.allclose(fxt_img_four_channels, img_decoded)
+            if image_backend == image_module.ImageBackend.cv2 or channels == 1:
+                assert np.allclose(original_image, img_decoded)
             else:
                 # PIL will return RGBA, thus we need to correct the fixture
-                to_rgb = fxt_img_four_channels[:, :, :3][:, :, ::-1]
-                fxt_img_four_channels[:, :, :3] = to_rgb
+                to_rgb = original_image[:, :, :3][:, :, ::-1]
+                original_image[:, :, :3] = to_rgb
 
-                assert np.allclose(fxt_img_four_channels, img_decoded)
+                assert np.allclose(original_image, img_decoded)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -1,13 +1,19 @@
+# Copyright (C) 2019-2024 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
 import os.path as osp
 from itertools import product
 from unittest import TestCase
 
 import numpy as np
 import PIL
+import pytest
 
 import datumaro.util.image as image_module
 
-from tests.requirements import Requirements, mark_requirement
+from ..requirements import Requirements, mark_requirement
+
 from tests.utils.test_utils import TestDir
 
 
@@ -107,3 +113,52 @@ class ImageOperationsTest(TestCase):
                 image_module.IMAGE_BACKEND.set(load_backend)
                 img = image_module.load_image(image_path)
                 assert img.shape == (10, 15, 3)
+
+
+class ImageDecodeTest:
+    @pytest.fixture
+    def fxt_img_four_channels(self) -> np.ndarray:
+        return np.random.randint(low=0, high=256, size=(5, 4, 4), dtype=np.uint8)
+
+    @pytest.mark.parametrize(
+        "image_backend", [image_module.ImageBackend.cv2, image_module.ImageBackend.PIL]
+    )
+    def test_decode_image_context(
+        self, fxt_img_four_channels: np.ndarray, image_backend: image_module.ImageBackend
+    ):
+        img_bytes = image_module.encode_image(fxt_img_four_channels, ".png")
+
+        # 3 channels from ImageColorScale.COLOR_BGR
+        with image_module.decode_image_context(
+            image_backend, image_module.ImageColorChannel.COLOR_BGR
+        ):
+            img_decoded = image_module.decode_image(img_bytes)
+            assert img_decoded.shape[-1] == 3
+            assert np.allclose(fxt_img_four_channels[:, :, :3], img_decoded)
+
+        # 3 channels from ImageColorScale.COLOR_RGB
+        with image_module.decode_image_context(
+            image_backend, image_module.ImageColorChannel.COLOR_RGB
+        ):
+            img_decoded = image_module.decode_image(img_bytes)
+            assert img_decoded.shape[-1] == 3
+            assert np.allclose(
+                fxt_img_four_channels[:, :, :3][:, :, ::-1],  # Flip color channels of the fixture
+                img_decoded,
+            )
+
+        # 4 channels from ImageColorScale.UNCHANGED
+        with image_module.decode_image_context(
+            image_backend, image_module.ImageColorChannel.UNCHANGED
+        ):
+            img_decoded = image_module.decode_image(img_bytes)
+            assert img_decoded.shape[-1] == 4
+
+            if image_backend == image_module.ImageBackend.cv2:
+                assert np.allclose(fxt_img_four_channels, img_decoded)
+            else:
+                # PIL will return RGBA, thus we need to correct the fixture
+                to_rgb = fxt_img_four_channels[:, :, :3][:, :, ::-1]
+                fxt_img_four_channels[:, :, :3] = to_rgb
+
+                assert np.allclose(fxt_img_four_channels, img_decoded)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -32,26 +32,27 @@ class ImageOperationsTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_save_and_load_backends(self):
         backends = image_module.ImageBackend
-        for save_backend, load_backend, c in product(backends, backends, [1, 3]):
+        for save_backend, load_backend, c in product(backends, backends, [1, 3, 4]):
             with TestDir() as test_dir:
                 src_image = generate_test_img(c)
                 path = osp.join(test_dir, "img.png")  # lossless
 
                 image_module.IMAGE_BACKEND.set(save_backend)
-                image_module.save_image(path, src_image, jpeg_quality=100)
+                image_module.save_image(path, src_image)
 
                 image_module.IMAGE_BACKEND.set(load_backend)
                 dst_image = image_module.load_image(path)
 
                 # If image_module.IMAGE_COLOR_CHANNEL.get() == image_module.ImageColorChannel.UNCHANGED
                 # OpenCV will read an image as BGR(A), but PIL will read an image as RGB(A).
-                if (
-                    c == 3
-                    and load_backend == image_module.ImageBackend.PIL
+                if c in [3, 4] and (
+                    load_backend == image_module.ImageBackend.PIL
                     and image_module.IMAGE_COLOR_CHANNEL.get()
                     == image_module.ImageColorChannel.UNCHANGED
+                    or image_module.IMAGE_COLOR_CHANNEL.get()
+                    == image_module.ImageColorChannel.COLOR_RGB
                 ):
-                    dst_image = np.flip(dst_image, -1)
+                    dst_image[..., :3] = dst_image[..., 2::-1]  # to bgr
 
                 self.assertTrue(
                     np.array_equal(src_image, dst_image),
@@ -61,24 +62,25 @@ class ImageOperationsTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_encode_and_decode_backends(self):
         backends = image_module.ImageBackend
-        for save_backend, load_backend, c in product(backends, backends, [1, 3]):
+        for save_backend, load_backend, c in product(backends, backends, [1, 3, 4]):
             src_image = generate_test_img(c)
 
             image_module.IMAGE_BACKEND.set(save_backend)
-            buffer = image_module.encode_image(src_image, ".png", jpeg_quality=100)  # lossless
+            buffer = image_module.encode_image(src_image, ".png")  # lossless
 
             image_module.IMAGE_BACKEND.set(load_backend)
             dst_image = image_module.decode_image(buffer)
 
             # If image_module.IMAGE_COLOR_CHANNEL.get() == image_module.ImageColorChannel.UNCHANGED
             # OpenCV will read an image as BGR(A), but PIL will read an image as RGB(A).
-            if (
-                c == 3
-                and load_backend == image_module.ImageBackend.PIL
+            if c in [3, 4] and (
+                load_backend == image_module.ImageBackend.PIL
                 and image_module.IMAGE_COLOR_CHANNEL.get()
                 == image_module.ImageColorChannel.UNCHANGED
+                or image_module.IMAGE_COLOR_CHANNEL.get()
+                == image_module.ImageColorChannel.COLOR_RGB
             ):
-                dst_image = np.flip(dst_image, -1)
+                dst_image[..., :3] = dst_image[..., 2::-1]  # to bgr
 
             self.assertTrue(
                 np.array_equal(src_image, dst_image),


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Resolves #83 

- Supported new RGB image reading option from OpenCV 4.11

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
