### PR TITLE
Memory optimizing cityscapes import

### DIFF
--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -16,8 +16,8 @@ import numpy as np
 from datumaro.components.annotation import (
     AnnotationType,
     CompiledMask,
+    ExtractedMask,
     LabelCategories,
-    Mask,
     MaskCategories,
     RgbColor,
 )
@@ -30,7 +30,7 @@ from datumaro.components.importer import Importer
 from datumaro.components.media import Image
 from datumaro.util import find
 from datumaro.util.annotation_util import make_label_id_mapping
-from datumaro.util.image import find_images, load_image, save_image
+from datumaro.util.image import find_images, lazy_image, save_image
 from datumaro.util.mask_tools import generate_colormap, paint_mask
 from datumaro.util.meta_file_util import (
     has_meta_file,
@@ -303,8 +303,8 @@ class CityscapesBase(SubsetBase):
             item_id = self._get_id_from_mask_path(mask_path, mask_suffix)
 
             anns = []
-            instances_mask = load_image(mask_path, dtype=np.int32)
-            segm_ids = np.unique(instances_mask)
+            instances_mask = lazy_image(mask_path, dtype=np.int32)
+            segm_ids = np.unique(instances_mask())
             for segm_id in segm_ids:
                 # either is_crowd or ann_id should be set
                 if segm_id < 1000:
@@ -316,8 +316,9 @@ class CityscapesBase(SubsetBase):
                     is_crowd = False
                     ann_id = segm_id % 1000
                 anns.append(
-                    Mask(
-                        image=self._lazy_extract_mask(instances_mask, segm_id),
+                    ExtractedMask(
+                        index_mask=instances_mask,
+                        index=segm_id,
                         label=label_id,
                         id=ann_id,
                         attributes={"is_crowd": is_crowd},
@@ -341,10 +342,6 @@ class CityscapesBase(SubsetBase):
             self._path, use_train_label_map=mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
         )
         return items
-
-    @staticmethod
-    def _lazy_extract_mask(mask, c):
-        return lambda: mask == c
 
 
 class CityscapesImporter(Importer):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Cityscapes on import reads all instances masks into ram and keeps them there. It consumes a lot of RAM if there are a lot of them. 
This PR stops doing it. Instead, masks will be read several times

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
