### PR TITLE
Fix dataset detection with Mac special dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/openvinotoolkit/datumaro/pull/678>)
 - Detection for Cityscapes format
   (<https://github.com/openvinotoolkit/datumaro/pull/680>)
-- Maximum recursion `--depth` parameter for `detect-dataset` CLI command
+- Maximum recursion `--depth` parameter for `detect` CLI command
   (<https://github.com/openvinotoolkit/datumaro/pull/680>)
 - An option to save a single subset in the `download` command
   (<https://github.com/openvinotoolkit/datumaro/pull/697>)
@@ -113,6 +113,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/45>)
 - Failing `resize` transform for RLE masks
   (<https://github.com/cvat-ai/datumaro/pull/46>)
+- Invalid handling of Mac OS special dirs in format detection
+  (<https://github.com/cvat-ai/datumaro/pull/88>)
 
 ### Security
 - TBD

--- a/src/datumaro/components/environment.py
+++ b/src/datumaro/components/environment.py
@@ -13,7 +13,7 @@ from typing import Callable, List, Optional, Sequence
 from datumaro.components.cli_plugin import plugin_types
 from datumaro.components.format_detection import RejectionReason, detect_dataset_format
 from datumaro.components.registry import PluginRegistry
-from datumaro.util.os_util import import_foreign_module, split_path
+from datumaro.util.os_util import SPECIAL_MACOS_FOLDERS, import_foreign_module, split_path
 
 
 class Environment:
@@ -208,7 +208,8 @@ class Environment:
         depth: int = 1,
         rejection_callback: Optional[Callable[[str, RejectionReason, str], None]] = None,
     ) -> List[str]:
-        ignore_dirs = {"__MSOSX", "__MACOSX"}
+        ignore_dirs = SPECIAL_MACOS_FOLDERS
+
         matched_formats = set()
         for _ in range(depth + 1):
             detected_formats = detect_dataset_format(
@@ -225,9 +226,12 @@ class Environment:
             elif detected_formats:
                 matched_formats |= set(detected_formats)
 
-            paths = glob.glob(osp.join(path, "*"))
-            path = "" if len(paths) != 1 else paths[0]
-            if not osp.isdir(path) or osp.basename(path) in ignore_dirs:
+            # If there is only a single nested dir, recurse into it up to the allowed level
+            nested_paths = [
+                p for p in glob.glob(osp.join(path, "*")) if osp.basename(p) not in ignore_dirs
+            ]
+            path = "" if len(nested_paths) != 1 else nested_paths[0]
+            if not path or not osp.isdir(path):
                 break
 
         return [format.name for format in matched_formats]

--- a/tests/integration/cli/test_detect_format.py
+++ b/tests/integration/cli/test_detect_format.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 import os.path as osp
+from pathlib import Path
 import shutil
 from typing import List
 from unittest.case import TestCase
@@ -11,7 +12,7 @@ from datumaro.plugins.data_formats.ade20k2017 import Ade20k2017Importer
 from datumaro.plugins.data_formats.ade20k2020 import Ade20k2020Importer
 from datumaro.plugins.data_formats.camvid import CamvidImporter
 from datumaro.plugins.data_formats.lfw import LfwImporter
-from datumaro.util.os_util import suppress_output
+from datumaro.util.os_util import SPECIAL_MACOS_FOLDERS, is_subpath, suppress_output
 
 from tests.requirements import Requirements, mark_requirement
 from tests.utils.assets import get_test_asset_path
@@ -76,6 +77,29 @@ class DetectFormatTest(TestCase):
             output = self._extract_detect_format_name(output_file)
 
             self.assertEqual([Ade20k2020Importer.NAME], output)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_ignore_special_dirs_in_nested_folders(self):
+        with TestDir() as test_dir:
+            output_file = io.StringIO()
+
+            annotation_dir = osp.join(test_dir, "a", "b", "c", "annotations")
+            os.makedirs(annotation_dir)
+            shutil.copy(osp.join(LFW_DIR, "test", "annotations", "pairs.txt"), annotation_dir)
+
+            for subdir_path in Path(annotation_dir).parents:
+                if not is_subpath(str(subdir_path), test_dir):
+                    continue
+
+                for special_dir_name in SPECIAL_MACOS_FOLDERS:
+                    (subdir_path / special_dir_name).mkdir(exist_ok=True)
+
+            with contextlib.redirect_stdout(output_file):
+                run(self, "detect", test_dir, "--depth", "3")
+
+            output = self._extract_detect_format_name(output_file)
+
+            self.assertEqual([LfwImporter.NAME], output)
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_ambiguous(self):

--- a/tests/integration/cli/test_detect_format.py
+++ b/tests/integration/cli/test_detect_format.py
@@ -3,8 +3,8 @@ import io
 import json
 import os
 import os.path as osp
-from pathlib import Path
 import shutil
+from pathlib import Path
 from typing import List
 from unittest.case import TestCase
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Fixed an invalid condition leading to failures in Mac special dir handling in dataset detection

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

https://github.com/cvat-ai/cvat/issues/8991

[test_yolo_macos_with_images.zip](https://github.com/user-attachments/files/19029049/test_yolo_macos_with_images.zip)
[test_yolo_macos.zip](https://github.com/user-attachments/files/19029051/test_yolo_macos.zip)

Download, unzip, run `datum detect path/` on the unzipped dirs. Should output `yolo`.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
