### PR TITLE
Avoid image decoding in ImageFromBytes.save() if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/71>)
 - Support for tracks in Ultralytics YOLO formats
   (<https://github.com/cvat-ai/datumaro/pull/70>)
+- \[API\] `ByteImage.save()` now preserves image extension if no output extension is specified
+  (<https://github.com/cvat-ai/datumaro/pull/91>)
+- \[API\] `ByteImage.save()` now guarantees there will be no extra image encoding/decoding
+  when possible (e.g. if input and output extension is the same)
+  (<https://github.com/cvat-ai/datumaro/pull/91>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/71>)
 - Support for tracks in Ultralytics YOLO formats
   (<https://github.com/cvat-ai/datumaro/pull/70>)
-- \[API\] `ByteImage.save()` now preserves image extension if no output extension is specified
+- \[API\] `ImageFromBytes.save()` now preserves image extension if no output extension is specified
   (<https://github.com/cvat-ai/datumaro/pull/91>)
-- \[API\] `ByteImage.save()` now guarantees there will be no extra image encoding/decoding
+- \[API\] `ImageFromBytes.save()` now guarantees there will be no extra image encoding/decoding
   when possible (e.g. if input and output extension is the same)
   (<https://github.com/cvat-ai/datumaro/pull/91>)
 

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -291,7 +291,7 @@ class Image(MediaElement[np.ndarray]):
             assert ext is None, "'ext' must be empty if string is given."
             ext = osp.splitext(osp.basename(fp))[1].lower()
         else:
-            ext = ext if ext else self._DEFAULT_EXT
+            ext = ext or self.ext or self._DEFAULT_EXT
         return ext
 
     def __eq__(self, other):
@@ -463,7 +463,7 @@ class ImageFromBytes(ImageFromData):
     ):
         new_ext = self._get_ext_to_save(fp, ext)
 
-        if self.ext == new_ext and crypter.is_null_crypter or crypter == self.crypter:
+        if self.ext == new_ext and (crypter.is_null_crypter or crypter == self._crypter):
             if isinstance(fp, str):
                 os.makedirs(osp.dirname(fp), exist_ok=True)
             data = self.bytes

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -455,6 +455,26 @@ class ImageFromBytes(ImageFromData):
             self._size = tuple(map(int, data.shape[:2]))
         return data
 
+    def save(
+        self,
+        fp: Union[str, io.IOBase],
+        ext: Optional[str] = None,
+        crypter: Crypter = NULL_CRYPTER,
+    ):
+        new_ext = self._get_ext_to_save(fp, ext)
+
+        if self.ext == new_ext:
+            if isinstance(fp, str):
+                os.makedirs(osp.dirname(fp), exist_ok=True)
+            data = super().data
+            if isinstance(fp, str):
+                with open(fp, "wb") as f:
+                    f.write(data)
+            else:
+                fp.write(data)
+        else:
+            super().save(fp=fp, ext=ext, crypter=crypter)
+
     def get_data_as_dtype(self, dtype: Optional[np.dtype] = np.uint8) -> Optional[np.ndarray]:
         """Get image data with a specific data type"""
 

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -463,15 +463,10 @@ class ImageFromBytes(ImageFromData):
     ):
         new_ext = self._get_ext_to_save(fp, ext)
 
-        if self.ext == new_ext and (crypter.is_null_crypter or crypter == self._crypter):
+        if self.ext == new_ext:
             if isinstance(fp, str):
                 os.makedirs(osp.dirname(fp), exist_ok=True)
-            data = self.bytes
-            if isinstance(fp, str):
-                with open(fp, "wb") as f:
-                    f.write(data)
-            else:
-                fp.write(data)
+            copyto_image(io.BytesIO(self.bytes), fp, src_crypter=self._crypter, dst_crypter=crypter)
         else:
             super().save(fp=fp, ext=ext, crypter=crypter)
 

--- a/src/datumaro/components/media.py
+++ b/src/datumaro/components/media.py
@@ -463,10 +463,10 @@ class ImageFromBytes(ImageFromData):
     ):
         new_ext = self._get_ext_to_save(fp, ext)
 
-        if self.ext == new_ext:
+        if self.ext == new_ext and crypter.is_null_crypter or crypter == self.crypter:
             if isinstance(fp, str):
                 os.makedirs(osp.dirname(fp), exist_ok=True)
-            data = super().data
+            data = self.bytes
             if isinstance(fp, str):
                 with open(fp, "wb") as f:
                     f.write(data)

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -1,11 +1,15 @@
+import itertools
 import os.path as osp
+from io import BytesIO
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 
+from datumaro.components.crypter import NULL_CRYPTER, Crypter
 from datumaro.components.media import Image, ImageFromBytes
 from datumaro.util.image import (
+    decode_image,
     encode_image,
     lazy_image,
     load_image_meta_file,
@@ -166,17 +170,67 @@ class BytesImageTest(TestCase):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_no_excess_decode_on_image_save(self):
+        def check_decode_call_count(image: Image, expected_call_count: int, **kwargs):
+            with patch(
+                "datumaro.components.media.decode_image", Mock(wraps=decode_image)
+            ) as mock_decode:
+                image.save(**kwargs)
+                assert mock_decode.call_count == expected_call_count
+
         with TestDir() as test_dir:
             image_np = np.ones([2, 4, 3])
 
-            extensions = ["png", "bmp", "jpg"]
-            for source_ext, save_ext in zip(extensions, extensions):
-                with self.subTest(source_ext=source_ext, save_ext=save_ext):
+            implicit_extensions = {".png", ".bmp", ".jpg"}
+            extensions = {
+                ".jpg",
+                ".png",
+                ".bmp",
+                ".tif",
+                ".tiff",
+                ".webp",
+                ".pfm",
+                ".sr",
+                ".ras",
+                ".hdr",
+                ".pic",
+                ".pnm",
+            }
+            crypters = [NULL_CRYPTER, Crypter(Crypter.gen_key())]
+            for source_ext, save_ext, save_crypter, explicit_ext in itertools.product(
+                extensions, extensions, crypters, [True, False]
+            ):
+                with self.subTest(
+                    source_ext=source_ext, save_ext=save_ext, save_crypter=save_crypter
+                ):
                     image_bytes = encode_image(image_np, source_ext)
-                    img = Image.from_bytes(data=image_bytes)
-                    mimg = Mock(wraps=img)
-                    mimg.save(osp.join(test_dir, f"path_{source_ext}.{save_ext}"))
-                    assert mimg.data.call_count == 0 if source_ext == save_ext else 1
+                    img = Image.from_bytes(
+                        data=image_bytes, ext=source_ext if explicit_ext else None
+                    )
+
+                    knows_current_extension = source_ext in implicit_extensions or explicit_ext
+
+                    # test determine target extension from path
+                    check_decode_call_count(
+                        img,
+                        (0 if knows_current_extension and source_ext == save_ext else 1),
+                        fp=osp.join(test_dir, f"name{save_ext}"),
+                        crypter=save_crypter,
+                    )
+                    # test explicit target extension and fp
+                    check_decode_call_count(
+                        img,
+                        (0 if knows_current_extension and source_ext == save_ext else 1),
+                        fp=BytesIO(),
+                        ext=save_ext,
+                        crypter=save_crypter,
+                    )
+                    # test extension not passed
+                    check_decode_call_count(
+                        img,
+                        (0 if knows_current_extension else 1),
+                        fp=BytesIO(),
+                        crypter=save_crypter,
+                    )
 
 
 class ImageMetaTest(TestCase):

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -1,5 +1,6 @@
 import os.path as osp
 from unittest import TestCase
+from unittest.mock import Mock
 
 import numpy as np
 
@@ -7,7 +8,6 @@ from datumaro.components.media import Image, ImageFromBytes
 from datumaro.util.image import (
     encode_image,
     lazy_image,
-    load_image,
     load_image_meta_file,
     save_image,
     save_image_meta_file,
@@ -163,6 +163,20 @@ class BytesImageTest(TestCase):
         image_bytes = b"\xff" * 10  # invalid image
         image = ImageFromBytes(data=image_bytes)
         self.assertEqual(image.ext, None)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_no_excess_decode_on_image_save(self):
+        with TestDir() as test_dir:
+            image_np = np.ones([2, 4, 3])
+
+            extensions = ["png", "bmp", "jpg"]
+            for source_ext, save_ext in zip(extensions, extensions):
+                with self.subTest(source_ext=source_ext, save_ext=save_ext):
+                    image_bytes = encode_image(image_np, source_ext)
+                    img = Image.from_bytes(data=image_bytes)
+                    mimg = Mock(wraps=img)
+                    mimg.save(osp.join(test_dir, f"path_{source_ext}.{save_ext}"))
+                    assert mimg.data.call_count == 0 if source_ext == save_ext else 1
 
 
 class ImageMetaTest(TestCase):

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -134,7 +134,6 @@ class BytesImageTest(TestCase):
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_ctors(self):
         with TestDir() as test_dir:
-            path = osp.join(test_dir, "path.png")
             image = np.ones([2, 4, 3])
             image_bytes = encode_image(image, "png")
 
@@ -188,14 +187,13 @@ class BytesImageTest(TestCase):
         with TestDir() as test_dir:
             image_np = np.ones([2, 4, 3])
 
-            implicit_extensions = [ext for _, ext in ImageFromBytes._FORMAT_MAGICS]
+            implicit_extensions = set(ext for _, ext in ImageFromBytes._FORMAT_MAGICS)
             extensions = {".png", ".bmp", ".jpg", ".tif", ".pic", ".ras"}
-            assert any(ext in implicit_extensions for ext in extensions)
-            assert any(ext not in implicit_extensions for ext in extensions)
+            assert extensions & implicit_extensions
+            assert extensions - implicit_extensions
 
-            crypters = [NULL_CRYPTER, Crypter(Crypter.gen_key())]
             for source_ext, save_ext, save_crypter, explicit_ext in itertools.product(
-                extensions, extensions, crypters, [True, False]
+                extensions, extensions, [NULL_CRYPTER, Crypter(Crypter.gen_key())], [True, False]
             ):
                 with self.subTest(
                     source_ext=source_ext,
@@ -217,6 +215,7 @@ class BytesImageTest(TestCase):
                         fp=osp.join(test_dir, f"name{save_ext}"),
                         crypter=save_crypter,
                     )
+
                     # test explicit target extension and fp
                     check_decode_call_count(
                         img,
@@ -225,6 +224,7 @@ class BytesImageTest(TestCase):
                         ext=save_ext,
                         crypter=save_crypter,
                     )
+
                     # test extension not passed
                     check_decode_call_count(
                         img,

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -177,6 +177,8 @@ class BytesImageTest(TestCase):
             with patch(
                 "datumaro.components.media.decode_image", Mock(wraps=decode_image)
             ) as mock_decode:
+                # Only OpenCV backend implements crypter support, so force it.
+                # https://github.com/cvat-ai/datumaro/issues/92
                 with decode_image_context(
                     image_backend=ImageBackend.cv2, image_color_channel=ImageColorChannel.UNCHANGED
                 ):

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -186,8 +186,11 @@ class BytesImageTest(TestCase):
         with TestDir() as test_dir:
             image_np = np.ones([2, 4, 3])
 
-            implicit_extensions = {".png", ".bmp", ".jpg"}
-            extensions = implicit_extensions | {".tif", ".pic", ".ras"}
+            implicit_extensions = [ext for _, ext in ImageFromBytes._FORMAT_MAGICS]
+            extensions = {".png", ".bmp", ".jpg", ".tif", ".pic", ".ras"}
+            assert any(ext in implicit_extensions for ext in extensions)
+            assert any(ext not in implicit_extensions for ext in extensions)
+
             crypters = [NULL_CRYPTER, Crypter(Crypter.gen_key())]
             for source_ext, save_ext, save_crypter, explicit_ext in itertools.product(
                 extensions, extensions, crypters, [True, False]

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -9,7 +9,10 @@ import numpy as np
 from datumaro.components.crypter import NULL_CRYPTER, Crypter
 from datumaro.components.media import Image, ImageFromBytes
 from datumaro.util.image import (
+    ImageBackend,
+    ImageColorChannel,
     decode_image,
+    decode_image_context,
     encode_image,
     lazy_image,
     load_image_meta_file,
@@ -174,33 +177,26 @@ class BytesImageTest(TestCase):
             with patch(
                 "datumaro.components.media.decode_image", Mock(wraps=decode_image)
             ) as mock_decode:
-                image.save(**kwargs)
-                assert mock_decode.call_count == expected_call_count
+                with decode_image_context(
+                    image_backend=ImageBackend.cv2, image_color_channel=ImageColorChannel.UNCHANGED
+                ):
+                    image.save(**kwargs)
+                    assert mock_decode.call_count == expected_call_count
 
         with TestDir() as test_dir:
             image_np = np.ones([2, 4, 3])
 
             implicit_extensions = {".png", ".bmp", ".jpg"}
-            extensions = {
-                ".jpg",
-                ".png",
-                ".bmp",
-                ".tif",
-                ".tiff",
-                ".webp",
-                ".pfm",
-                ".sr",
-                ".ras",
-                ".hdr",
-                ".pic",
-                ".pnm",
-            }
+            extensions = implicit_extensions | {".tif", ".pic", ".ras"}
             crypters = [NULL_CRYPTER, Crypter(Crypter.gen_key())]
             for source_ext, save_ext, save_crypter, explicit_ext in itertools.product(
                 extensions, extensions, crypters, [True, False]
             ):
                 with self.subTest(
-                    source_ext=source_ext, save_ext=save_ext, save_crypter=save_crypter
+                    source_ext=source_ext,
+                    save_ext=save_ext,
+                    save_crypter=save_crypter,
+                    explicit_ext=explicit_ext,
                 ):
                     image_bytes = encode_image(image_np, source_ext)
                     img = Image.from_bytes(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Added support for preserving image extension if no output extension is specified in `ImageFromBytes.save()`
- `ImageFromBytes.save()` now guarantees there is no extra image encoding/decoding if possible (e.g. if input and output extension is the same)

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
