### PR TITLE
use rapidjson to write ann files in coco streaming export

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -9,6 +9,7 @@ nibabel>=3.2.1
 numpy<2,>=1.22.2
 orjson==3.10.12
 Pillow>=10.3.0
+python-rapidjson==1.20
 ruamel.yaml>=0.17.0
 shapely>=1.7
 typing_extensions>=3.7.4.3

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -9,7 +9,6 @@ nibabel>=3.2.1
 numpy<2,>=1.22.2
 orjson==3.10.12
 Pillow>=10.3.0
-python-rapidjson==1.20
 ruamel.yaml>=0.17.0
 shapely>=1.7
 typing_extensions>=3.7.4.3
@@ -51,6 +50,9 @@ tabulate
 
 # prune
 scikit-learn
+
+# Stream JSON dumper
+python-rapidjson==1.20
 
 # TabularValidator
 nltk

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -52,9 +52,6 @@ tabulate
 # prune
 scikit-learn
 
-# Stream JSON parser
-json-stream
-
 # TabularValidator
 nltk
 

--- a/src/datumaro/plugins/data_formats/coco/exporter.py
+++ b/src/datumaro/plugins/data_formats/coco/exporter.py
@@ -11,8 +11,8 @@ from io import BufferedWriter
 from itertools import chain, groupby
 from typing import Dict, List, Optional, Type, Union
 
-import orjson
 import pycocotools.mask as mask_utils
+import rapidjson
 
 import datumaro.util.annotation_util as anno_tools
 import datumaro.util.mask_tools as mask_tools
@@ -108,7 +108,7 @@ class TemporaryWriters:
         def _gen_images():
             with open(self.imgs.fp.name, "rb") as fp:
                 for line in fp:
-                    yield orjson.Fragment(line)
+                    yield parse_json(line)
 
         def _gen_anns():
             with open(self.anns.fp.name, "rb") as fp:
@@ -118,14 +118,16 @@ class TemporaryWriters:
                     if min_ann_id is not None and not ann["id"]:
                         ann["id"] = next_id
                         next_id += 1
-                    yield orjson.Fragment(dump_json(ann))
+                    yield ann
 
         data = dict(
             header,
-            images=[] if self.imgs.is_empty else list(_gen_images()),
-            annotations=[] if self.anns.is_empty else list(_gen_anns()),
+            images=[] if self.imgs.is_empty else _gen_images(),
+            annotations=[] if self.anns.is_empty else _gen_anns(),
         )
-        dump_json_file(path, data)
+
+        with open(path, "w", encoding="utf-8") as fp:
+            rapidjson.dump(data, fp, indent=None)
 
         self.remove()
 

--- a/src/datumaro/plugins/data_formats/coco/exporter.py
+++ b/src/datumaro/plugins/data_formats/coco/exporter.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
 import logging as log
 import os
 import os.path as osp
@@ -12,8 +11,8 @@ from io import BufferedWriter
 from itertools import chain, groupby
 from typing import Dict, List, Optional, Type, Union
 
+import orjson
 import pycocotools.mask as mask_utils
-from json_stream.writer import streamable_dict, streamable_list
 
 import datumaro.util.annotation_util as anno_tools
 import datumaro.util.mask_tools as mask_tools
@@ -106,13 +105,11 @@ class TemporaryWriters:
     def merge(self, path: str, header: Dict, min_ann_id: Optional[int]) -> None:
         self.close()
 
-        @streamable_list
         def _gen_images():
             with open(self.imgs.fp.name, "rb") as fp:
                 for line in fp:
-                    yield parse_json(line)
+                    yield orjson.Fragment(line)
 
-        @streamable_list
         def _gen_anns():
             with open(self.anns.fp.name, "rb") as fp:
                 next_id = min_ann_id
@@ -121,26 +118,14 @@ class TemporaryWriters:
                     if min_ann_id is not None and not ann["id"]:
                         ann["id"] = next_id
                         next_id += 1
-                    yield ann
+                    yield orjson.Fragment(dump_json(ann))
 
-        @streamable_dict
-        def _gen():
-            yield "licenses", header["licenses"]
-            yield "info", header["info"]
-            yield "categories", header["categories"]
-
-            if not self.imgs.is_empty:
-                yield "images", _gen_images()
-            else:
-                yield "images", []
-
-            if not self.anns.is_empty:
-                yield "annotations", _gen_anns()
-            else:
-                yield "annotations", []
-
-        with open(path, "w", encoding="utf-8") as fp:
-            json.dump(_gen(), fp)
+        data = dict(
+            header,
+            images=[] if self.imgs.is_empty else list(_gen_images()),
+            annotations=[] if self.anns.is_empty else list(_gen_anns()),
+        )
+        dump_json_file(path, data)
 
         self.remove()
 

--- a/src/datumaro/util/__init__.py
+++ b/src/datumaro/util/__init__.py
@@ -6,11 +6,10 @@ import inspect
 from functools import wraps
 from inspect import isclass
 from itertools import islice
-from typing import Any, Callable, Dict, Iterable, Tuple, TypeVar, Union
+from typing import Any, Callable, Iterable, Tuple, TypeVar, Union
 
 import attrs
 import orjson
-from json_stream.base import StreamingJSONList, StreamingJSONObject
 
 NOTSET = object()
 
@@ -204,11 +203,3 @@ def dump_json_file(
 
 def current_function_name(depth=1):
     return inspect.getouterframes(inspect.currentframe())[depth].function
-
-
-def to_dict_from_streaming_json(obj: Any) -> Dict[str, Any]:
-    if isinstance(obj, StreamingJSONObject):
-        return {k: to_dict_from_streaming_json(v) for k, v in obj.items()}
-    if isinstance(obj, StreamingJSONList):
-        return [to_dict_from_streaming_json(v) for v in obj]
-    return obj


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Switched to rapidjson in COCO streaming exporter for better performance
- Removed unused `json-stream` dependency

[Measurements and comparisons](https://github.com/cvat-ai/datumaro/pull/94#discussion_r1987253177), ~1.8x speedup with the same memory use.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
