### PR TITLE
fixing skeleton sublabels exclusion

### DIFF
--- a/src/datumaro/plugins/data_formats/yolo/exporter.py
+++ b/src/datumaro/plugins/data_formats/yolo/exporter.py
@@ -252,10 +252,19 @@ class YoloExporter(Exporter):
 
     @cached_property
     def _labels_to_save(self) -> List[int]:
+        label_categories = self._extractor.categories()[AnnotationType.label]
+        point_categories = self._extractor.categories().get(
+            AnnotationType.points, PointsCategories.from_iterable([])
+        )
+        skeleton_sublabels = [
+            label_categories.find(sublabel, parent=label_categories[parent_label_id].name)[0]
+            for parent_label_id in point_categories.items
+            for sublabel in point_categories.items[parent_label_id].labels
+        ]
         return [
             label_id
-            for label_id, label in enumerate(self._extractor.categories()[AnnotationType.label])
-            if label.parent == ""
+            for label_id, label in enumerate(label_categories)
+            if label_id not in skeleton_sublabels
         ]
 
     @cached_property

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -566,7 +566,7 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
             require_media=True,
         )
 
-    def test_saves_only_parentless_labels(self, test_dir):
+    def test_does_not_save_skeleton_sublabels(self, test_dir):
         anno1 = self._generate_random_annotation(label=1)
         anno3 = self._generate_random_annotation(label=3)
 
@@ -579,22 +579,31 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
                     annotations=[anno1, anno3],
                 ),
             ],
-            categories=[
-                "label_wo_parent",
-                "parent_label",
-                ("child_label_1", "parent_label"),
-                "another_label_wo_parent",
-                ("child_label_2", "parent_label"),
-                ("child_label_3", "parent_label"),
-                "one_more_label_wo_parent",
-            ],
+            categories={
+                AnnotationType.label: LabelCategories.from_iterable(
+                    [
+                        "label_wo_parent",
+                        "skeleton_label",
+                        ("child_label_1", "skeleton_label"),
+                        "another_label_wo_parent",
+                        ("child_label_2", "skeleton_label"),
+                        ("child_label_3", "skeleton_label"),
+                        "one_more_label_wo_parent",
+                    ]
+                ),
+                AnnotationType.points: PointsCategories.from_iterable(
+                    [
+                        (1, ["child_label_1", "child_label_2", "child_label_3"], {(0, 1)}),
+                    ],
+                ),
+            },
         )
         self.CONVERTER.convert(source_dataset, test_dir, save_media=True)
         with open(osp.join(test_dir, "data.yaml"), "r") as f:
             config = yaml.safe_load(f)
             assert config["names"] == {
                 0: "label_wo_parent",
-                1: "parent_label",
+                1: "skeleton_label",
                 2: "another_label_wo_parent",
                 3: "one_more_label_wo_parent",
             }
@@ -610,7 +619,7 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
             ],
             categories=[
                 "label_wo_parent",
-                "parent_label",
+                "skeleton_label",
                 "another_label_wo_parent",
                 "one_more_label_wo_parent",
             ],
@@ -915,7 +924,7 @@ class YoloUltralyticsPoseExporterTest(YoloUltralyticsDetectionExporterTest):
         assert osp.isfile(osp.join(test_dir, "dataset_meta.json"))
         self.compare_datasets(source_dataset, parsed_dataset)
 
-    def test_saves_only_parentless_labels(self, test_dir):
+    def test_does_not_save_skeleton_sublabels(self, test_dir):
         # should save only skeleton labels
         source_dataset = Dataset.from_iterable(
             [

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -589,6 +589,8 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
                         ("child_label_2", "skeleton_label"),
                         ("child_label_3", "skeleton_label"),
                         "one_more_label_wo_parent",
+                        "not_skeleton_parent",
+                        ("child_label_4", "not_skeleton_parent"),
                     ]
                 ),
                 AnnotationType.points: PointsCategories.from_iterable(
@@ -606,6 +608,8 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
                 1: "skeleton_label",
                 2: "another_label_wo_parent",
                 3: "one_more_label_wo_parent",
+                4: "not_skeleton_parent",
+                5: "child_label_4",
             }
         anno3.label = 2
         expected_dataset = Dataset.from_iterable(
@@ -622,6 +626,8 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
                 "skeleton_label",
                 "another_label_wo_parent",
                 "one_more_label_wo_parent",
+                "not_skeleton_parent",
+                "child_label_4",
             ],
         )
         parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
