### PR TITLE
Remove extra bandit config

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,8 +1,0 @@
-[bandit]
-# B101 : assert_used
-# B102 : exec_used
-# B320 : xml_bad_etree
-# B404 : import_subprocess
-# B406 : import_xml_sax
-# B410 : import_lxml
-skips: B101,B102,B320,B404,B406,B410


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

There were 2 bandit configs in the repo:
`.bandit`
`.ci/ipas_default.config`

They have conflicting rules. Removed `.bandit` to use the most recent one.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
