### PR TITLE
improving streaming subsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - \[API\] `ImageFromBytes.save()` now guarantees there will be no extra image encoding/decoding
   when possible (e.g. if input and output extension is the same)
   (<https://github.com/cvat-ai/datumaro/pull/91>)
+- \[API\] Added `StreamingDatasetBase` as a utility base type for user-created extractors
+  with streaming support. Added support for using `get_subset()` from the source dataset
+  in `StreamDataset` during iteration, when possible.
+  (<https://github.com/cvat-ai/datumaro/pull/97>)
 
 ### Changed
 - `env.detect_dataset()` now returns a list of detected formats at all recursion levels

--- a/src/datumaro/components/dataset_base.py
+++ b/src/datumaro/components/dataset_base.py
@@ -13,6 +13,7 @@ from attr import attrs, field
 from datumaro.components.annotation import Annotation, Annotations, AnnotationType, Categories
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.contexts.importer import ImportContext, NullImportContext
+from datumaro.components.errors import NotAvailableError
 from datumaro.components.media import Image, MediaElement
 from datumaro.util.attrs_util import default_if_none, not_empty
 from datumaro.util.definitions import DEFAULT_SUBSET_NAME
@@ -284,7 +285,31 @@ class SubsetBase(DatasetBase):
 
 class StreamingDatasetBase(DatasetBase):
     """
-    A base class for user-defined and built-in extractors.
-    Should be used in cases, where SubsetBase is not enough,
-    or its use makes problems with performance, implementation etc.
+    A base class for multi-subset extractors adapted for streaming export.
+    Should be used in cases when number of items and subsets are known beforehand
+    and subsets can be accessed independently.
+
+    get_subset method should be redefined
     """
+
+    def __init__(self, *, length: Optional[int] = None, subsets: Optional[Sequence[str]] = None):
+        assert length is not None
+        assert subsets is not None
+        super().__init__(length=length, subsets=subsets)
+
+    def __iter__(self):
+        for subset in self.subsets().values():
+            yield from subset
+
+    def get(self, id, subset=None) -> Optional[DatasetItem]:
+        raise NotAvailableError("Random access to the item is not allowed in streaming.")
+
+    def _init_cache(self):
+        raise NotAvailableError()
+
+    @property
+    def is_stream(self) -> bool:
+        return True
+
+    def get_subset(self, name) -> IDataset:
+        raise NotImplementedError()

--- a/src/datumaro/components/dataset_base.py
+++ b/src/datumaro/components/dataset_base.py
@@ -280,3 +280,11 @@ class SubsetBase(DatasetBase):
     def subset(self) -> str:
         """Subset name of this instance."""
         return self._subset
+
+
+class StreamingDatasetBase(DatasetBase):
+    """
+    A base class for user-defined and built-in extractors.
+    Should be used in cases, where SubsetBase is not enough,
+    or its use makes problems with performance, implementation etc.
+    """

--- a/src/datumaro/components/dataset_base.py
+++ b/src/datumaro/components/dataset_base.py
@@ -13,7 +13,7 @@ from attr import attrs, field
 from datumaro.components.annotation import Annotation, Annotations, AnnotationType, Categories
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.contexts.importer import ImportContext, NullImportContext
-from datumaro.components.errors import NotAvailableError
+from datumaro.components.errors import DatumaroError, NotAvailableError
 from datumaro.components.media import Image, MediaElement
 from datumaro.util.attrs_util import default_if_none, not_empty
 from datumaro.util.definitions import DEFAULT_SUBSET_NAME
@@ -301,8 +301,8 @@ class StreamingDatasetBase(DatasetBase):
         ann_types: Optional[Set[AnnotationType]] = None,
         ctx: Optional[ImportContext] = None,
     ):
-        assert length is not None
-        assert subsets is not None
+        if length is None or subsets is None:
+            raise DatumaroError("StreamingDatasetBase should receive non-empty length and subsets")
         super().__init__(
             length=length, subsets=subsets, media_type=media_type, ann_types=ann_types, ctx=ctx
         )
@@ -312,7 +312,7 @@ class StreamingDatasetBase(DatasetBase):
             yield from subset
 
     def get(self, id, subset=None) -> Optional[DatasetItem]:
-        raise NotAvailableError("Random access to the item is not allowed in streaming.")
+        raise NotAvailableError("Random access to items is not allowed in streaming.")
 
     def _init_cache(self):
         raise NotAvailableError()

--- a/src/datumaro/components/dataset_base.py
+++ b/src/datumaro/components/dataset_base.py
@@ -292,10 +292,20 @@ class StreamingDatasetBase(DatasetBase):
     get_subset method should be redefined
     """
 
-    def __init__(self, *, length: Optional[int] = None, subsets: Optional[Sequence[str]] = None):
+    def __init__(
+        self,
+        *,
+        length: Optional[int] = None,
+        subsets: Optional[Sequence[str]] = None,
+        media_type: Type[MediaElement] = Image,
+        ann_types: Optional[Set[AnnotationType]] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert length is not None
         assert subsets is not None
-        super().__init__(length=length, subsets=subsets)
+        super().__init__(
+            length=length, subsets=subsets, media_type=media_type, ann_types=ann_types, ctx=ctx
+        )
 
     def __iter__(self):
         for subset in self.subsets().values():

--- a/src/datumaro/components/dataset_storage.py
+++ b/src/datumaro/components/dataset_storage.py
@@ -703,17 +703,22 @@ class StreamDatasetStorage(DatasetStorage):
         log.debug("This function has no effect on streaming.")
         pass
 
-    @property
-    def stacked_transform(self) -> IDataset:
+    def _make_stacked_transfrom(self, source: IDataset):
         if self._transforms:
             transform = _StackedTransform(
-                self._source,
+                source,
                 self._transforms,
                 raise_on_malformed_transform=self._raise_on_malformed_transform,
             )
             self._drop_malformed_transforms(transform.malformed_transform_indices)
         else:
-            transform = self._source
+            transform = source
+
+        return transform
+
+    @property
+    def stacked_transform(self) -> IDataset:
+        transform = self._make_stacked_transfrom(self._source)
 
         self._flush_changes = True
         return transform
@@ -745,7 +750,12 @@ class StreamDatasetStorage(DatasetStorage):
         raise NotAvailableError("Drop-in removal is not allowed in streaming.")
 
     def get_subset(self, name: str) -> IDataset:
-        return self.subsets()[name]
+        if all(t[0].KEEPS_SUBSETS_INTACT for t in self._transforms):
+            transformed_subset = self._make_stacked_transfrom(self._source.get_subset(name))
+            if transformed_subset.is_stream:
+                return StreamSubset(transformed_subset, name)
+
+        return StreamSubset(self, name)
 
     @property
     def subset_names(self):
@@ -760,7 +770,7 @@ class StreamDatasetStorage(DatasetStorage):
         return self._subset_names
 
     def subsets(self) -> Dict[str, IDataset]:
-        return {subset: StreamSubset(self, subset) for subset in self.subset_names}
+        return {subset: self.get_subset(subset) for subset in self.subset_names}
 
     def transform(self, method: Type[Transform], *args, **kwargs) -> None:
         super().transform(method, *args, **kwargs)

--- a/src/datumaro/components/dataset_storage.py
+++ b/src/datumaro/components/dataset_storage.py
@@ -703,7 +703,7 @@ class StreamDatasetStorage(DatasetStorage):
         log.debug("This function has no effect on streaming.")
         pass
 
-    def _make_stacked_transfrom(self, source: IDataset):
+    def _apply_stacked_transform(self, source: IDataset):
         if self._transforms:
             transform = _StackedTransform(
                 source,
@@ -718,7 +718,7 @@ class StreamDatasetStorage(DatasetStorage):
 
     @property
     def stacked_transform(self) -> IDataset:
-        transform = self._make_stacked_transfrom(self._source)
+        transform = self._apply_stacked_transform(self._source)
 
         self._flush_changes = True
         return transform
@@ -751,7 +751,7 @@ class StreamDatasetStorage(DatasetStorage):
 
     def get_subset(self, name: str) -> IDataset:
         if all(t[0].KEEPS_SUBSETS_INTACT for t in self._transforms):
-            transformed_subset = self._make_stacked_transfrom(self._source.get_subset(name))
+            transformed_subset = self._apply_stacked_transform(self._source.get_subset(name))
             if transformed_subset.is_stream:
                 return StreamSubset(transformed_subset, name)
 

--- a/src/datumaro/components/transformer.py
+++ b/src/datumaro/components/transformer.py
@@ -62,6 +62,10 @@ class Transform(DatasetBase, CliPlugin):
     def infos(self) -> DatasetInfo:
         return self._extractor.infos()
 
+    @property
+    def is_stream(self) -> bool:
+        return self._extractor.is_stream
+
 
 class ItemTransform(Transform):
     def transform_item(self, item: DatasetItem) -> Optional[DatasetItem]:

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -43,6 +43,8 @@ class DummyStreamingExtractor(StreamingDatasetBase):
                 assert sys.getrefcount(item) == 2
 
                 # after yielded, there are more references (e.g. where it's yielded from)
+                # number of references doesn't have to increase in general,
+                # but it should due to how our code works
                 yield item
                 assert sys.getrefcount(item) > 2
 

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 
@@ -11,8 +13,8 @@ from datumaro.components.media import Image
 
 class DummyStreamingExtractor(StreamingDatasetBase):
     def __init__(self):
-        super().__init__(length=3, subsets=["train", "test", "foo"])
-        self.iter_subset_call_count = 0
+        super().__init__(length=6, subsets=["train", "test", "foo"])
+        self.iter_subset_call_dict = {subset: 0 for subset in self._subsets}
         self.iter_call_count = 0
 
     def __iter__(self):
@@ -20,7 +22,7 @@ class DummyStreamingExtractor(StreamingDatasetBase):
         yield from super().__iter__()
 
     def get_subset(self, name: str) -> IDataset:
-        assert name in ["train", "test", "foo"]
+        assert name in self._subsets
 
         class _SubsetExtractor(SubsetBase):
             def __init__(self, parent):
@@ -28,13 +30,30 @@ class DummyStreamingExtractor(StreamingDatasetBase):
                 self.parent = parent
 
             def __iter__(self):
-                self.parent.iter_subset_call_count += 1
-                yield DatasetItem(
+                self.parent.iter_subset_call_dict[name] += 1
+                item = DatasetItem(
                     id=f"{name}_1",
                     subset=name,
                     media=Image.from_numpy(data=np.ones((4, 2, 3))),
                     annotations=[],
                 )
+                # counting references to make sure that exporter is actually streaming
+
+                # before yielded, references are only here
+                assert sys.getrefcount(item) == 2
+
+                # after yielded, there are more references (e.g. where it's yielded from)
+                yield item
+                assert sys.getrefcount(item) > 2
+
+                # after next item yielded, ref count is 2 again - i.e. item was not saved anywhere
+                yield DatasetItem(
+                    id=f"{name}_2",
+                    subset=name,
+                    media=Image.from_numpy(data=np.ones((4, 2, 3))),
+                    annotations=[],
+                )
+                assert sys.getrefcount(item) == 2
 
             @property
             def is_stream(self):
@@ -53,11 +72,14 @@ def test_streaming_exporters_only_iterate_items_once(test_dir, exporter_cls):
     try:
         exporter_cls.convert(dataset, test_dir, stream=True)
     except DatasetExportError as e:
-        # not all exporters can export in stream manner - skipping them
         assert "cannot export a dataset in a stream manner" in str(e)
-        return
+        pytest.skip(f"{exporter_cls} does not support streaming")
 
     # there was no full iterations
     assert extractor.iter_call_count == 0
     # each subset was iterated once
-    assert extractor.iter_subset_call_count == len(extractor.subsets())
+    assert not {
+        subset: call_count
+        for subset, call_count in extractor.iter_subset_call_dict.items()
+        if call_count != 1
+    }

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+
+from datumaro import AnnotationType, CategoriesInfo, LabelCategories
+from datumaro.components.dataset import StreamDataset
+from datumaro.components.dataset_base import DatasetBase, DatasetItem, IDataset, SubsetBase
+from datumaro.components.environment import DEFAULT_ENVIRONMENT
+from datumaro.components.errors import DatasetExportError
+from datumaro.components.media import Image
+
+
+class DummyStreamingExtractor(DatasetBase):
+    def __init__(self):
+        super().__init__(length=3, subsets=["train", "test", "foo"])
+        self.iter_subset_call_count = 0
+        self.iter_call_count = 0
+
+    def __iter__(self):
+        self.iter_call_count += 1
+        for subset in self.subsets().values():
+            yield from subset
+
+    def get_subset(self, name: str) -> IDataset:
+        assert name in ["train", "test", "foo"]
+
+        class _SubsetExtractor(SubsetBase):
+            def __init__(self, parent):
+                super().__init__(subset=name)
+                self.parent = parent
+
+            def __iter__(self):
+                self.parent.iter_subset_call_count += 1
+                yield DatasetItem(
+                    id=str(id),
+                    subset=name,
+                    media=Image.from_numpy(data=np.ones((4, 2, 3))),
+                    annotations=[],
+                )
+
+            @property
+            def is_stream(self):
+                return True
+
+        return _SubsetExtractor(self)
+
+    @property
+    def is_stream(self):
+        return True
+
+    def categories(self) -> CategoriesInfo:
+        return {AnnotationType.label: LabelCategories.from_iterable(["a", "b", "c"])}
+
+
+@pytest.mark.parametrize("exporter_cls", DEFAULT_ENVIRONMENT.exporters.items.values())
+def test_streaming_exporters_only_iterate_items_once(test_dir, exporter_cls):
+    extractor = DummyStreamingExtractor()
+    dataset = StreamDataset(source=extractor)
+    try:
+        exporter_cls.convert(dataset, test_dir, stream=True)
+    except DatasetExportError as e:
+        # not all exporters can export in stream manner - skipping them
+        assert "cannot export a dataset in a stream manner" in str(e)
+        return
+
+    # there was no full iterations
+    assert extractor.iter_call_count == 0
+    # each subset was iterated once
+    assert extractor.iter_subset_call_count == len(extractor.subsets())

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -3,13 +3,13 @@ import pytest
 
 from datumaro import AnnotationType, CategoriesInfo, LabelCategories
 from datumaro.components.dataset import StreamDataset
-from datumaro.components.dataset_base import DatasetBase, DatasetItem, IDataset, SubsetBase
+from datumaro.components.dataset_base import DatasetItem, IDataset, StreamingDatasetBase, SubsetBase
 from datumaro.components.environment import DEFAULT_ENVIRONMENT
 from datumaro.components.errors import DatasetExportError
 from datumaro.components.media import Image
 
 
-class DummyStreamingExtractor(DatasetBase):
+class DummyStreamingExtractor(StreamingDatasetBase):
     def __init__(self):
         super().__init__(length=3, subsets=["train", "test", "foo"])
         self.iter_subset_call_count = 0
@@ -17,8 +17,7 @@ class DummyStreamingExtractor(DatasetBase):
 
     def __iter__(self):
         self.iter_call_count += 1
-        for subset in self.subsets().values():
-            yield from subset
+        yield from super().__iter__()
 
     def get_subset(self, name: str) -> IDataset:
         assert name in ["train", "test", "foo"]
@@ -42,10 +41,6 @@ class DummyStreamingExtractor(DatasetBase):
                 return True
 
         return _SubsetExtractor(self)
-
-    @property
-    def is_stream(self):
-        return True
 
     def categories(self) -> CategoriesInfo:
         return {AnnotationType.label: LabelCategories.from_iterable(["a", "b", "c"])}

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -30,7 +30,7 @@ class DummyStreamingExtractor(StreamingDatasetBase):
             def __iter__(self):
                 self.parent.iter_subset_call_count += 1
                 yield DatasetItem(
-                    id=str(id),
+                    id=f"{name}_1",
                     subset=name,
                     media=Image.from_numpy(data=np.ones((4, 2, 3))),
                     annotations=[],

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -21,7 +21,7 @@ from datumaro.components.annotation import (
     Skeleton,
 )
 from datumaro.components.dataset import Dataset, StreamDataset
-from datumaro.components.dataset_base import DatasetItem, SubsetBase
+from datumaro.components.dataset_base import DatasetBase, DatasetItem, IDataset, SubsetBase
 from datumaro.components.environment import Environment
 from datumaro.components.errors import (
     AnnotationImportError,
@@ -2432,30 +2432,48 @@ class CocoStreamExporterTest(CocoExporterTest):
 
     def test_can_export_stream(self):
         iter_call_count = 0
+        iter_subset_call_count = 0
 
-        class DummyStreamExtractor(SubsetBase):
+        class DummyStreamExtractor(DatasetBase):
             def categories(self):
                 return {AnnotationType.label: LabelCategories.from_iterable(["a", "b"])}
-
-            def __len__(self):
-                return 1
 
             def __iter__(self):
                 nonlocal iter_call_count
                 iter_call_count += 1
-                yield DatasetItem(
-                    id=str(id),
-                    media=Image.from_numpy(data=np.ones((4, 2, 3))),
-                    annotations=[Polygon([0, 0, 4, 0, 4, 4], label=0, id=5)],
-                )
+                for subset in self.subsets().values():
+                    yield from subset
+
+            def get_subset(self, name: str) -> IDataset:
+                assert name in ["train", "test"]
+
+                class _SubsetExtractor(SubsetBase):
+                    def __iter__(self):
+                        nonlocal iter_subset_call_count
+                        iter_subset_call_count += 1
+                        yield DatasetItem(
+                            id=str(id),
+                            subset=name,
+                            media=Image.from_numpy(data=np.ones((4, 2, 3))),
+                            annotations=[Polygon([0, 0, 4, 0, 4, 4], label=0, id=5)],
+                        )
+
+                    @property
+                    def is_stream(self):
+                        return True
+
+                return _SubsetExtractor(subset=name)
 
             @property
             def is_stream(self) -> bool:
                 return True
 
         dataset = StreamDataset.from_extractors(
-            DummyStreamExtractor(media_type=Image, subset="default")
+            DummyStreamExtractor(media_type=Image, subsets=["train", "test"], length=2)
         )
         with TestDir() as test_dir:
             CocoInstancesExporter.convert(dataset, test_dir, stream=True)
-        assert iter_call_count == 1
+        # there was no full iterations
+        assert iter_call_count == 0
+        # each subset was iterated once
+        assert iter_subset_call_count == 2

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -44,7 +44,6 @@ from datumaro.plugins.data_formats.coco.exporter import (
     CocoPersonKeypointsExporter,
     CocoStuffExporter,
 )
-from datumaro.plugins.data_formats.coco.importer import CocoImporter
 from datumaro.util import dump_json_file
 
 from tests.requirements import Requirements, mark_requirement
@@ -2429,51 +2428,3 @@ class CocoStreamExporterTest(CocoExporterTest):
             stream=True,
             **kwargs,
         )
-
-    def test_can_export_stream(self):
-        iter_call_count = 0
-        iter_subset_call_count = 0
-
-        class DummyStreamExtractor(DatasetBase):
-            def categories(self):
-                return {AnnotationType.label: LabelCategories.from_iterable(["a", "b"])}
-
-            def __iter__(self):
-                nonlocal iter_call_count
-                iter_call_count += 1
-                for subset in self.subsets().values():
-                    yield from subset
-
-            def get_subset(self, name: str) -> IDataset:
-                assert name in ["train", "test"]
-
-                class _SubsetExtractor(SubsetBase):
-                    def __iter__(self):
-                        nonlocal iter_subset_call_count
-                        iter_subset_call_count += 1
-                        yield DatasetItem(
-                            id=str(id),
-                            subset=name,
-                            media=Image.from_numpy(data=np.ones((4, 2, 3))),
-                            annotations=[Polygon([0, 0, 4, 0, 4, 4], label=0, id=5)],
-                        )
-
-                    @property
-                    def is_stream(self):
-                        return True
-
-                return _SubsetExtractor(subset=name)
-
-            @property
-            def is_stream(self) -> bool:
-                return True
-
-        dataset = StreamDataset.from_extractors(
-            DummyStreamExtractor(media_type=Image, subsets=["train", "test"], length=2)
-        )
-        with TestDir() as test_dir:
-            CocoInstancesExporter.convert(dataset, test_dir, stream=True)
-        # there was no full iterations
-        assert iter_call_count == 0
-        # each subset was iterated once
-        assert iter_subset_call_count == 2

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -20,8 +20,8 @@ from datumaro.components.annotation import (
     Polygon,
     Skeleton,
 )
-from datumaro.components.dataset import Dataset, StreamDataset
-from datumaro.components.dataset_base import DatasetBase, DatasetItem, IDataset, SubsetBase
+from datumaro.components.dataset import Dataset
+from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import Environment
 from datumaro.components.errors import (
     AnnotationImportError,

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -25,7 +25,7 @@ from datumaro.components.contexts.importer import (
     ProgressReporter,
 )
 from datumaro.components.dataset import DEFAULT_FORMAT, Dataset, StreamDataset, eager_mode
-from datumaro.components.dataset_base import DatasetBase, DatasetItem, SubsetBase
+from datumaro.components.dataset_base import DatasetBase, DatasetItem, IDataset, SubsetBase
 from datumaro.components.dataset_item_storage import ItemStatus
 from datumaro.components.environment import Environment
 from datumaro.components.errors import (
@@ -2437,11 +2437,32 @@ class StreamDatasetTest:
                     subsets=list(items_for_subsets.keys()),
                 )
                 self.iter_counter = 0
+                self.iter_subset_counter = 0
 
             def __iter__(self):
                 self.iter_counter += 1
-                for subset, (start_id, end_id) in items_for_subsets.items():
-                    yield from StreamDatasetTest._gen_items(start_id, end_id, subset)
+                for subset in self.subsets().values():
+                    yield from subset
+
+            def get_subset(self, name: str) -> IDataset:
+                assert name in items_for_subsets
+
+                class _SubsetExtractor(SubsetBase):
+                    def __init__(self, parent):
+                        super().__init__(subset=name)
+                        self.parent = parent
+
+                    def __iter__(self):
+                        self.parent.iter_subset_counter += 1
+                        yield from StreamDatasetTest._gen_items(
+                            items_for_subsets[name][0], items_for_subsets[name][1], name
+                        )
+
+                    @property
+                    def is_stream(self):
+                        return True
+
+                return _SubsetExtractor(self)
 
             @property
             def is_stream(self):
@@ -2457,18 +2478,22 @@ class StreamDatasetTest:
         assert len(dataset) == 2
         # does not iterate items to get any of the above info
         assert extractor.iter_counter == 0
+        assert extractor.iter_subset_counter == 0
 
         # does not cache items
         assert len(list(dataset)) == 2
         assert extractor.iter_counter == 1
+        assert extractor.iter_subset_counter == 1
         assert len(list(dataset)) == 2
         assert extractor.iter_counter == 2
+        assert extractor.iter_subset_counter == 2
 
-        # when accessing items through subsets, iterates over them only once
+        # when accessing items through subsets, iterates over only over subset items
         assert (
             len([item for subset_name, subset in dataset.subsets().items() for item in subset]) == 2
         )
-        assert extractor.iter_counter == 3
+        assert extractor.iter_counter == 2
+        assert extractor.iter_subset_counter == 3
 
     def test_subset_keeping_transforms_do_not_trigger_subset_recollection(self):
         extractor = self._make_extractor({"train": (1, 3), "val": (3, 5)})
@@ -2476,6 +2501,7 @@ class StreamDatasetTest:
         dataset = dataset.transform(BoxesToMasks)
         assert set(dataset.subsets().keys()) == {"train", "val"}
         assert extractor.iter_counter == 0
+        assert extractor.iter_subset_counter == 0
 
     def test_subset_changing_transforms_trigger_subset_recollection(self):
         extractor = self._make_extractor({"train": (1, 3), "val": (3, 6)})
@@ -2483,9 +2509,11 @@ class StreamDatasetTest:
         dataset = dataset.transform(MapSubsets, mapping={"train": "another"})
         assert set(dataset.subsets().keys()) == {"another", "val"}
         assert extractor.iter_counter == 1
+        assert extractor.iter_subset_counter == 2
         # subset names now cached
         assert set(dataset.subsets().keys()) == {"another", "val"}
         assert extractor.iter_counter == 1
+        assert extractor.iter_subset_counter == 2
 
     def test_several_subsets(self):
         extractor = self._make_extractor({"train": (1, 3), "val": (3, 6), "test": (9, 13)})
@@ -2497,15 +2525,20 @@ class StreamDatasetTest:
         assert len(dataset) == 9
         # does not iterate items to get any of the above info
         assert extractor.iter_counter == 0
+        assert extractor.iter_subset_counter == 0
 
         # does not cache items
         assert len(list(dataset)) == 9
         assert extractor.iter_counter == 1
+        assert extractor.iter_subset_counter == 3
         assert len(list(dataset)) == 9
         assert extractor.iter_counter == 2
+        assert extractor.iter_subset_counter == 6
 
-        # when accessing items through subsets, iterates over them once for each subset
+        # when accessing items through subsets, does not iterate over all items
+        # iterates over each subset once
         assert (
             len([item for subset_name, subset in dataset.subsets().items() for item in subset]) == 9
         )
-        assert extractor.iter_counter == 5
+        assert extractor.iter_counter == 2
+        assert extractor.iter_subset_counter == 9

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -2433,8 +2433,10 @@ class StreamDatasetTest:
             )
 
     @staticmethod
-    def _make_extractor_dataset_base(items_for_subsets: Dict[str, Tuple[int, int]]):
-        class SrcExtractor(DatasetBase):
+    def _make_extractor(
+        items_for_subsets: Dict[str, Tuple[int, int]], streaming_base: bool = False
+    ):
+        class SrcExtractor(StreamingDatasetBase if streaming_base else DatasetBase):
             def __init__(self):
                 super().__init__(
                     length=sum(
@@ -2444,64 +2446,44 @@ class StreamDatasetTest:
                 )
                 self.iter_counter = 0
                 self.iter_subset_counter = 0
+
+            @property
+            def is_stream(self):
+                return True
 
             def __iter__(self):
                 self.iter_counter += 1
                 for subset, (start_id, end_id) in items_for_subsets.items():
                     yield from StreamDatasetTest._gen_items(start_id, end_id, subset)
 
-            @property
-            def is_stream(self):
-                return True
-
-        return SrcExtractor()
-
-    @staticmethod
-    def _make_extractor_streaming_base(items_for_subsets: Dict[str, Tuple[int, int]]):
-        class SrcExtractor(StreamingDatasetBase):
-            def __init__(self):
-                super().__init__(
-                    length=sum(
-                        end_id - start_id for start_id, end_id in items_for_subsets.values()
-                    ),
-                    subsets=list(items_for_subsets.keys()),
-                )
-                self.iter_counter = 0
-                self.iter_subset_counter = 0
-
-            def __iter__(self):
-                self.iter_counter += 1
-                yield from super().__iter__()
-
-            def get_subset(self, name: str) -> IDataset:
-                assert name in items_for_subsets
-
-                class _SubsetExtractor(SubsetBase):
-                    def __init__(self, parent):
-                        super().__init__(subset=name)
-                        self.parent = parent
-
-                    def __iter__(self):
-                        self.parent.iter_subset_counter += 1
-                        yield from StreamDatasetTest._gen_items(
-                            items_for_subsets[name][0], items_for_subsets[name][1], name
-                        )
-
-                    @property
-                    def is_stream(self):
-                        return True
-
-                return _SubsetExtractor(self)
-
-        return SrcExtractor()
-
-    def _make_extractor(
-        self, items_for_subsets: Dict[str, Tuple[int, int]], streaming_base: bool = False
-    ):
         if streaming_base:
-            return self._make_extractor_streaming_base(items_for_subsets)
-        else:
-            return self._make_extractor_dataset_base(items_for_subsets)
+
+            class SrcExtractor(SrcExtractor):
+                def __iter__(self):
+                    self.iter_counter += 1
+                    yield from StreamingDatasetBase.__iter__(self)
+
+                def get_subset(self, name: str) -> IDataset:
+                    assert name in items_for_subsets
+
+                    class _SubsetExtractor(SubsetBase):
+                        def __init__(self, parent):
+                            super().__init__(subset=name)
+                            self.parent = parent
+
+                        def __iter__(self):
+                            self.parent.iter_subset_counter += 1
+                            yield from StreamDatasetTest._gen_items(
+                                items_for_subsets[name][0], items_for_subsets[name][1], name
+                            )
+
+                        @property
+                        def is_stream(self):
+                            return True
+
+                    return _SubsetExtractor(self)
+
+        return SrcExtractor()
 
     @pytest.mark.parametrize("streaming_base", [True, False])
     def test_single_subset(self, streaming_base):

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -25,7 +25,13 @@ from datumaro.components.contexts.importer import (
     ProgressReporter,
 )
 from datumaro.components.dataset import DEFAULT_FORMAT, Dataset, StreamDataset, eager_mode
-from datumaro.components.dataset_base import DatasetBase, DatasetItem, IDataset, SubsetBase
+from datumaro.components.dataset_base import (
+    DatasetBase,
+    DatasetItem,
+    IDataset,
+    StreamingDatasetBase,
+    SubsetBase,
+)
 from datumaro.components.dataset_item_storage import ItemStatus
 from datumaro.components.environment import Environment
 from datumaro.components.errors import (
@@ -2427,7 +2433,7 @@ class StreamDatasetTest:
             )
 
     @staticmethod
-    def _make_extractor(items_for_subsets: Dict[str, Tuple[int, int]]):
+    def _make_extractor_dataset_base(items_for_subsets: Dict[str, Tuple[int, int]]):
         class SrcExtractor(DatasetBase):
             def __init__(self):
                 super().__init__(
@@ -2441,8 +2447,31 @@ class StreamDatasetTest:
 
             def __iter__(self):
                 self.iter_counter += 1
-                for subset in self.subsets().values():
-                    yield from subset
+                for subset, (start_id, end_id) in items_for_subsets.items():
+                    yield from StreamDatasetTest._gen_items(start_id, end_id, subset)
+
+            @property
+            def is_stream(self):
+                return True
+
+        return SrcExtractor()
+
+    @staticmethod
+    def _make_extractor_streaming_base(items_for_subsets: Dict[str, Tuple[int, int]]):
+        class SrcExtractor(StreamingDatasetBase):
+            def __init__(self):
+                super().__init__(
+                    length=sum(
+                        end_id - start_id for start_id, end_id in items_for_subsets.values()
+                    ),
+                    subsets=list(items_for_subsets.keys()),
+                )
+                self.iter_counter = 0
+                self.iter_subset_counter = 0
+
+            def __iter__(self):
+                self.iter_counter += 1
+                yield from super().__iter__()
 
             def get_subset(self, name: str) -> IDataset:
                 assert name in items_for_subsets
@@ -2464,14 +2493,19 @@ class StreamDatasetTest:
 
                 return _SubsetExtractor(self)
 
-            @property
-            def is_stream(self):
-                return True
-
         return SrcExtractor()
 
-    def test_single_subset(self):
-        extractor = self._make_extractor({"train": (1, 3)})
+    def _make_extractor(
+        self, items_for_subsets: Dict[str, Tuple[int, int]], streaming_base: bool = False
+    ):
+        if streaming_base:
+            return self._make_extractor_streaming_base(items_for_subsets)
+        else:
+            return self._make_extractor_dataset_base(items_for_subsets)
+
+    @pytest.mark.parametrize("streaming_base", [True, False])
+    def test_single_subset(self, streaming_base):
+        extractor = self._make_extractor({"train": (1, 3)}, streaming_base)
         dataset = StreamDataset.from_extractors(extractor)
 
         assert list(dataset.subsets().keys()) == ["train"]
@@ -2483,17 +2517,21 @@ class StreamDatasetTest:
         # does not cache items
         assert len(list(dataset)) == 2
         assert extractor.iter_counter == 1
-        assert extractor.iter_subset_counter == 1
+        assert extractor.iter_subset_counter == (1 if streaming_base else 0)
         assert len(list(dataset)) == 2
         assert extractor.iter_counter == 2
-        assert extractor.iter_subset_counter == 2
+        assert extractor.iter_subset_counter == (2 if streaming_base else 0)
 
-        # when accessing items through subsets, iterates over only over subset items
+        # when accessing items through subsets
         assert (
             len([item for subset_name, subset in dataset.subsets().items() for item in subset]) == 2
         )
-        assert extractor.iter_counter == 2
-        assert extractor.iter_subset_counter == 3
+        if streaming_base:
+            # iterates only over subset items
+            assert extractor.iter_counter == 2
+            assert extractor.iter_subset_counter == 3
+        else:
+            assert extractor.iter_counter == 3
 
     def test_subset_keeping_transforms_do_not_trigger_subset_recollection(self):
         extractor = self._make_extractor({"train": (1, 3), "val": (3, 5)})
@@ -2509,14 +2547,16 @@ class StreamDatasetTest:
         dataset = dataset.transform(MapSubsets, mapping={"train": "another"})
         assert set(dataset.subsets().keys()) == {"another", "val"}
         assert extractor.iter_counter == 1
-        assert extractor.iter_subset_counter == 2
         # subset names now cached
         assert set(dataset.subsets().keys()) == {"another", "val"}
         assert extractor.iter_counter == 1
-        assert extractor.iter_subset_counter == 2
 
-    def test_several_subsets(self):
-        extractor = self._make_extractor({"train": (1, 3), "val": (3, 6), "test": (9, 13)})
+    @pytest.mark.parametrize("streaming_base", [True, False])
+    def test_several_subsets(self, streaming_base):
+        extractor = self._make_extractor(
+            {"train": (1, 3), "val": (3, 6), "test": (9, 13)}, streaming_base=streaming_base
+        )
+
         dataset = StreamDataset.from_extractors(extractor)
         dataset = dataset.transform(BoxesToMasks)
         dataset = dataset.transform(MasksToPolygons)
@@ -2530,15 +2570,21 @@ class StreamDatasetTest:
         # does not cache items
         assert len(list(dataset)) == 9
         assert extractor.iter_counter == 1
-        assert extractor.iter_subset_counter == 3
+        if streaming_base:
+            assert extractor.iter_subset_counter == 3
         assert len(list(dataset)) == 9
         assert extractor.iter_counter == 2
-        assert extractor.iter_subset_counter == 6
+        if streaming_base:
+            assert extractor.iter_subset_counter == 6
 
-        # when accessing items through subsets, does not iterate over all items
-        # iterates over each subset once
+        # when accessing items through subsets
         assert (
             len([item for subset_name, subset in dataset.subsets().items() for item in subset]) == 9
         )
-        assert extractor.iter_counter == 2
-        assert extractor.iter_subset_counter == 9
+        if streaming_base:
+            # does not iterate over all items, iterates over each subset once
+            assert extractor.iter_counter == 2
+            assert extractor.iter_subset_counter == 9
+        else:
+            # iterates over all items, once for every subset
+            assert extractor.iter_counter == 5


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Current implementation of StreamDatasetStorage iterates over all items when only items of one subset are accessed. It means, when exporting multi-subset dataset, typical exporter will iterate over all the items several times.

Making ot possible to iterate subsets independently in this PR

- Source `get_subset()` in streaming now will be used when possible
- Added utility base class for dataset with streaming support

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
