### PR TITLE
Recursive find_sources for yolo classification format

### DIFF
--- a/src/datumaro/plugins/data_formats/yolo/importer.py
+++ b/src/datumaro/plugins/data_formats/yolo/importer.py
@@ -131,24 +131,37 @@ class YoloUltralyticsClassificationImporter(Importer):
     _FORMAT = YoloUltralyticsClassificationBase.NAME
     DETECT_CONFIDENCE = FormatDetectionConfidence.LOW
 
-    @classmethod
-    def find_sources(cls, path):
+    @staticmethod
+    def is_valid_source_folder(path: str) -> bool:
         if not osp.isdir(path):
-            return []
+            return False
         subfolders = [
             subfolder for name in os.listdir(path) if osp.isdir(subfolder := osp.join(path, name))
         ]
         if not subfolders:
-            return []
+            return False
         for subset_folder in subfolders:
             for name in os.listdir(subset_folder):
                 if name in [YoloUltralyticsClassificationFormat.LABELS_FILE, DATASET_META_FILE]:
                     continue
                 label_folder = osp.join(subset_folder, name)
                 if not osp.isdir(label_folder) or not contains_only_images(label_folder):
-                    return []
+                    return False
+        return True
 
-        return [{"url": path, "format": cls._FORMAT}]
+    @classmethod
+    def find_sources(cls, path) -> list[dict]:
+        if not osp.isdir(path):
+            return []
+
+        if cls.is_valid_source_folder(path):
+            return [{"url": path, "format": cls._FORMAT}]
+
+        return [
+            source
+            for source in cls._find_sources_recursive(path, "", cls._FORMAT)
+            if cls.is_valid_source_folder(source["url"])
+        ]
 
     @property
     def can_stream(self) -> bool:

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -34,7 +34,6 @@ from datumaro.components.errors import (
     DatasetImportError,
     DatasetNotFoundError,
     InvalidAnnotationError,
-    ItemImportError,
     UndeclaredLabelError,
 )
 from datumaro.components.format_detection import FormatDetectionContext, FormatRequirementsUnmet
@@ -1142,6 +1141,13 @@ class YoloImporterTest(CompareDatasetMixin):
     IMPORTER = YoloImporter
     ASSETS = ["yolo"]
 
+    def test_can_find_sources_in_subfolder(self, test_dir):
+        subfolder_path = osp.join(test_dir, "subfolder")
+        shutil.copytree(get_test_asset_path("yolo_dataset", self.ASSETS[0]), subfolder_path)
+        sources = self.IMPORTER()(test_dir)
+        assert len(sources) == 1
+        assert subfolder_path in sources[0]["url"]
+
     def test_can_detect(self):
         dataset_dir = get_test_asset_path("yolo_dataset", "yolo")
         detected_formats = Environment().detect_dataset(dataset_dir)
@@ -1469,6 +1475,14 @@ class YoloUltralyticsPoseImporterTest(YoloUltralyticsDetectionImporterTest):
 class YoloUltralyticsClassificationImporterTest(YoloImporterTest):
     IMPORTER = YoloUltralyticsClassificationImporter
     ASSETS = ["yolo_ultralytics_classification"]
+
+    def test_can_find_sources_in_subfolder(self, test_dir):
+        subfolder_path = osp.join(test_dir, "subfolder")
+        shutil.copytree(get_test_asset_path("yolo_dataset", self.ASSETS[0]), subfolder_path)
+        open(osp.join(subfolder_path, "random.file"), "w").close()
+        sources = self.IMPORTER()(test_dir)
+        assert len(sources) == 1
+        assert subfolder_path in sources[0]["url"]
 
     def test_can_detect(self):
         dataset_dir = get_test_asset_path("yolo_dataset", "yolo_ultralytics_classification")


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
unlike other YOLO formats, YOLO classification find_sources only checks given path for being a valid source folder, but does not check subfolders. Fixing it

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
