### PR TITLE
yolo import - getting image list from image_info if possible

### DIFF
--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -119,8 +119,7 @@ class _YoloBase(SubsetBase):
 
         if isinstance(item, str):
             try:
-                image_info_key = f"{item_id}{os.path.splitext(item)[1]}"
-                image_size = self._image_info.get(image_info_key)
+                image_size = self._image_info.get(item_id)
                 image_path = osp.join(self._path, item)
 
                 image = Image.from_file(path=image_path, size=image_size)
@@ -481,7 +480,7 @@ class YoloUltralyticsDetectionBase(YoloBase):
                     image_paths = [
                         osp.relpath(full_image_path, self._path)
                         for image_path in self._image_info
-                        for full_image_path in [osp.join(path, image_path)]
+                        for full_image_path in [osp.join(path, f"{image_path}.bmp")]
                         if osp.exists(self._get_labels_path_from_image_path(full_image_path))
                     ]
 

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -468,14 +468,15 @@ class YoloUltralyticsDetectionBase(YoloBase):
             else:
                 path = osp.join(self._path, self.localize_path(subset_images_source))
 
-                image_paths = []
-                if osp.isdir(path):
-                    image_paths = [
-                        osp.relpath(osp.join(root, file), self._path)
-                        for root, dirs, files in os.walk(path)
-                        for file in files
-                        if osp.isfile(osp.join(root, file))
-                    ]
+                if not osp.isdir(path):
+                    raise InvalidAnnotationError(f"Can't find '{subset_name}' subset image folder")
+
+                image_paths = [
+                    osp.relpath(osp.join(root, file), self._path)
+                    for root, dirs, files in os.walk(path)
+                    for file in files
+                    if osp.isfile(osp.join(root, file))
+                ]
                 if not image_paths and self._image_info:
                     image_paths = [
                         osp.relpath(full_image_path, self._path)

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -467,7 +467,6 @@ class YoloUltralyticsDetectionBase(YoloBase):
                 yield from super()._get_subset_image_paths(subset_name)
             else:
                 path = osp.join(self._path, self.localize_path(subset_images_source))
-
                 if not osp.isdir(path):
                     raise InvalidAnnotationError(f"Can't find '{subset_name}' subset image folder")
 

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -119,7 +119,8 @@ class _YoloBase(SubsetBase):
 
         if isinstance(item, str):
             try:
-                image_size = self._image_info.get(item_id)
+                image_info_key = os.path.join(subset_name, f"{item_id}{os.path.splitext(item)[1]}")
+                image_size = self._image_info.get(image_info_key)
                 image_path = osp.join(self._path, item)
 
                 image = Image.from_file(path=image_path, size=image_size)
@@ -467,14 +468,29 @@ class YoloUltralyticsDetectionBase(YoloBase):
                 yield from super()._get_subset_image_paths(subset_name)
             else:
                 path = osp.join(self._path, self.localize_path(subset_images_source))
-                if not osp.isdir(path):
-                    raise InvalidAnnotationError(f"Can't find '{subset_name}' subset image folder")
-                yield from (
-                    osp.relpath(osp.join(root, file), self._path)
-                    for root, dirs, files in os.walk(path)
-                    for file in files
-                    if osp.isfile(osp.join(root, file))
-                )
+
+                image_paths = []
+                if osp.isdir(path):
+                    image_paths = [
+                        osp.relpath(osp.join(root, file), self._path)
+                        for root, dirs, files in os.walk(path)
+                        for file in files
+                        if osp.isfile(osp.join(root, file))
+                    ]
+                if not image_paths and self._image_info:
+                    image_paths = [
+                        osp.relpath(osp.join(path, image_path), self._path)
+                        for image in self._image_info
+                        for image_subset_name, image_path in [image.split(osp.sep, 1)]
+                        if image_subset_name == subset_name
+                    ]
+
+                if not image_paths:
+                    raise InvalidAnnotationError(
+                        f"Can't find images for subset '{subset_name}' in {subset_images_source}"
+                    )
+
+                yield from image_paths
         else:
             yield from subset_images_source
 

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -119,7 +119,7 @@ class _YoloBase(SubsetBase):
 
         if isinstance(item, str):
             try:
-                image_info_key = os.path.join(subset_name, f"{item_id}{os.path.splitext(item)[1]}")
+                image_info_key = f"{item_id}{os.path.splitext(item)[1]}"
                 image_size = self._image_info.get(image_info_key)
                 image_path = osp.join(self._path, item)
 
@@ -479,10 +479,10 @@ class YoloUltralyticsDetectionBase(YoloBase):
                     ]
                 if not image_paths and self._image_info:
                     image_paths = [
-                        osp.relpath(osp.join(path, image_path), self._path)
-                        for image in self._image_info
-                        for image_subset_name, image_path in [image.split(osp.sep, 1)]
-                        if image_subset_name == subset_name
+                        osp.relpath(full_image_path, self._path)
+                        for image_path in self._image_info
+                        for full_image_path in [osp.join(path, image_path)]
+                        if osp.exists(self._get_labels_path_from_image_path(full_image_path))
                     ]
 
                 if not image_paths:

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -227,8 +227,13 @@ class YoloExporterTest(CompareDatasetMixin):
         )
 
         self.CONVERTER.convert(source_dataset, test_dir)
+
+        image_folder = osp.join(test_dir, "images")
+        if osp.exists(image_folder):
+            shutil.rmtree(osp.join(test_dir, "images"))
+
         parsed_dataset = Dataset.import_from(
-            test_dir, self.IMPORTER.NAME, image_info={list(source_dataset)[0].id: (10, 15)}
+            test_dir, self.IMPORTER.NAME, image_info={osp.join("train", "1.jpg"): (10, 15)}
         )
         self.compare_datasets(source_dataset, parsed_dataset)
 
@@ -636,6 +641,35 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
 
         parsed_dataset = Dataset.import_from(test_dir, self.IMPORTER.NAME)
         self.compare_datasets(expected_dataset, parsed_dataset)
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_load_dataset_with_exact_image_info_folder_in_datayaml(self, test_dir):
+        source_dataset = self._generate_random_dataset(
+            [
+                {
+                    "annotations": 2,
+                    "media": Image.from_file(path="1.jpg", size=(10, 15)),
+                },
+            ]
+        )
+
+        self.CONVERTER.convert(source_dataset, test_dir)
+
+        image_folder = osp.join(test_dir, "images")
+        if osp.exists(image_folder):
+            shutil.rmtree(osp.join(test_dir, "images"))
+
+        data_path = osp.join(test_dir, "data.yaml")
+        with open(data_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        data["train"] = osp.join("images", "train")
+        with open(data_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f)
+
+        parsed_dataset = Dataset.import_from(
+            test_dir, self.IMPORTER.NAME, image_info={osp.join("train", "1.jpg"): (10, 15)}
+        )
+        self.compare_datasets(source_dataset, parsed_dataset)
 
 
 class YoloUltralyticsSegmentationExporterTest(YoloUltralyticsDetectionExporterTest):
@@ -1705,7 +1739,7 @@ class YoloUltralyticsDetectionExtractorTest(YoloExtractorTest):
         with pytest.raises(DatasetImportError) as capture:
             Dataset.import_from(dataset_path, self.IMPORTER.NAME).init_cache()
         assert isinstance(capture.value.__cause__, InvalidAnnotationError)
-        assert "subset image folder" in str(capture.value.__cause__)
+        assert "Can't find images for subset 'train'" in str(capture.value.__cause__)
 
     def test_can_report_missing_ann_file(self, test_dir):
         # YoloUltralytics does not require annotation files

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -656,8 +656,8 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
         self.CONVERTER.convert(source_dataset, test_dir)
 
         image_folder = osp.join(test_dir, "images")
-        if osp.exists(image_folder):
-            shutil.rmtree(osp.join(test_dir, "images"))
+        shutil.rmtree(image_folder)
+        os.makedirs(osp.join(image_folder, "train"))
 
         data_path = osp.join(test_dir, "data.yaml")
         with open(data_path, "r", encoding="utf-8") as f:
@@ -1739,7 +1739,7 @@ class YoloUltralyticsDetectionExtractorTest(YoloExtractorTest):
         with pytest.raises(DatasetImportError) as capture:
             Dataset.import_from(dataset_path, self.IMPORTER.NAME).init_cache()
         assert isinstance(capture.value.__cause__, InvalidAnnotationError)
-        assert "Can't find images for subset 'train'" in str(capture.value.__cause__)
+        assert "subset image folder" in str(capture.value.__cause__)
 
     def test_can_report_missing_ann_file(self, test_dir):
         # YoloUltralytics does not require annotation files

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -233,7 +233,7 @@ class YoloExporterTest(CompareDatasetMixin):
             shutil.rmtree(osp.join(test_dir, "images"))
 
         parsed_dataset = Dataset.import_from(
-            test_dir, self.IMPORTER.NAME, image_info={"1.jpg": (10, 15)}
+            test_dir, self.IMPORTER.NAME, image_info={list(source_dataset)[0].id: (10, 15)}
         )
         self.compare_datasets(source_dataset, parsed_dataset)
 
@@ -667,7 +667,7 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
             yaml.dump(data, f)
 
         parsed_dataset = Dataset.import_from(
-            test_dir, self.IMPORTER.NAME, image_info={"1.jpg": (10, 15)}
+            test_dir, self.IMPORTER.NAME, image_info={list(source_dataset)[0].id: (10, 15)}
         )
         self.compare_datasets(source_dataset, parsed_dataset)
 

--- a/tests/unit/data_formats/test_yolo_format.py
+++ b/tests/unit/data_formats/test_yolo_format.py
@@ -233,7 +233,7 @@ class YoloExporterTest(CompareDatasetMixin):
             shutil.rmtree(osp.join(test_dir, "images"))
 
         parsed_dataset = Dataset.import_from(
-            test_dir, self.IMPORTER.NAME, image_info={osp.join("train", "1.jpg"): (10, 15)}
+            test_dir, self.IMPORTER.NAME, image_info={"1.jpg": (10, 15)}
         )
         self.compare_datasets(source_dataset, parsed_dataset)
 
@@ -667,7 +667,7 @@ class YoloUltralyticsDetectionExporterTest(YoloExporterTest):
             yaml.dump(data, f)
 
         parsed_dataset = Dataset.import_from(
-            test_dir, self.IMPORTER.NAME, image_info={osp.join("train", "1.jpg"): (10, 15)}
+            test_dir, self.IMPORTER.NAME, image_info={"1.jpg": (10, 15)}
         )
         self.compare_datasets(source_dataset, parsed_dataset)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

Ultralytics yolo subset can be specified as a folder in data.yaml. In that case, if there are only annotations (no images) in the dataset folder, importer finds no images, creates no items, and therefore does not read any annotations. 

Using image_info to get items. 


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
