### PR TITLE
fixing lazy annotations in coco and datumaro

### DIFF
--- a/src/datumaro/plugins/data_formats/coco/base.py
+++ b/src/datumaro/plugins/data_formats/coco/base.py
@@ -308,8 +308,9 @@ class _CocoBase(SubsetBase):
 
             yield item
             length += 1
-            for ann in item.annotations:
-                self._ann_types.add(ann.type)
+            if item.annotations_are_initialized:
+                for ann in item.annotations:
+                    self._ann_types.add(ann.type)
 
         self._length = length
 

--- a/src/datumaro/plugins/data_formats/datumaro/base.py
+++ b/src/datumaro/plugins/data_formats/datumaro/base.py
@@ -514,7 +514,7 @@ class StreamJsonReader(JsonReader):
             item = self._parse_item(item_desc)
             yield item
 
-            if item is not None:
+            if item is not None and item.annotations_are_initialized:
                 for ann in item.annotations:
                     ann_types.add(ann.type)
         self.ann_types = ann_types

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -158,25 +158,27 @@ def test_streaming_importers(test_dir, export_format, fxt_dataset):
         else:
             assert init_counter.count == 0
 
-        for item in parsed_dataset:
-            # annotations are not parsed if we do not access them
-            assert not item.annotations_are_initialized
+        # annotations are not parsed if we do not access them
+        items = list(iter(parsed_dataset))
+        assert all(not item.annotations_are_initialized for item in items)
+        del items
 
+        for item in parsed_dataset:
             # annotations are parsed if we access them
             assert isinstance(item.annotations, Annotations)
             assert item.annotations_are_initialized
 
-        assert init_counter.count == len(fxt_dataset)
+        assert init_counter.count == len(fxt_dataset) * 2
 
         # inits again on iteration, i.e. does not cache items
         for _ in parsed_dataset:
             pass
-        assert init_counter.count == len(fxt_dataset) * 2
+        assert init_counter.count == len(fxt_dataset) * 3
 
         # subset list can be accessed without making extra item iterations
         for _ in parsed_dataset.subsets().values():
             pass
-        assert init_counter.count == len(fxt_dataset) * 2
+        assert init_counter.count == len(fxt_dataset) * 3
 
         # subset access DOES ITERATE over ALL items in the dataset,
         # though item annotations and media data are not parsed before access
@@ -190,4 +192,4 @@ def test_streaming_importers(test_dir, export_format, fxt_dataset):
                 assert isinstance(item.annotations, Annotations)
                 assert item.annotations_are_initialized
 
-        assert init_counter.count == len(fxt_dataset) * (2 + len(parsed_dataset.subsets()))
+        assert init_counter.count == len(fxt_dataset) * (3 + len(parsed_dataset.subsets()))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Related #109

- Disabled dataset ann type info accumulation in COCO and Datumaro formats during lazy streaming

This is likely to be revisited once there is a clear use case for ann types info needed before dataset is parsed.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
