### PR TITLE
Can export COCO Keypoints when some points are absent

### DIFF
--- a/src/datumaro/plugins/data_formats/coco/exporter.py
+++ b/src/datumaro/plugins/data_formats/coco/exporter.py
@@ -571,7 +571,7 @@ class _KeypointsExporter(_InstancesExporter):
         if any(element.label is not None for element in ann.elements):
             # ... arrange them in order corresponding to
             # the order of those labels in the skeleton.
-            elements = [None] * len(ann.elements)
+            elements = [None] * len(self._point_label_to_position)
             for element in ann.elements:
                 elements[self._point_label_to_position[element.label]] = element
         else:
@@ -579,8 +579,12 @@ class _KeypointsExporter(_InstancesExporter):
             elements = ann.elements
 
         for element in elements:
-            points.extend(element.points)
-            visibility.extend(element.visibility)
+            if element is not None:
+                points.extend(element.points)
+                visibility.extend(element.visibility)
+            else:
+                points.extend([0, 0])
+                visibility.append(Points.Visibility.absent)
 
         for index in range(0, len(points), 2):
             kp = points[index : index + 2]

--- a/src/datumaro/plugins/data_formats/coco/exporter.py
+++ b/src/datumaro/plugins/data_formats/coco/exporter.py
@@ -5,6 +5,7 @@
 import logging as log
 import os
 import os.path as osp
+from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto
 from io import BufferedWriter
@@ -499,8 +500,8 @@ class _KeypointsExporter(_InstancesExporter):
             return
         point_categories = dataset.categories().get(AnnotationType.points)
 
-        # point label -> position of the point in the skeleton
-        self._point_label_to_position: Dict[int, int] = {}
+        # skeleton label -> {point label -> position of the point in the skeleton}
+        self._point_label_to_position: Dict[int, Dict[int, int]] = defaultdict(dict)
 
         for idx, label_cat in enumerate(label_categories.items):
             if not label_cat.parent:
@@ -527,7 +528,7 @@ class _KeypointsExporter(_InstancesExporter):
                                 point_name, parent=label_cat.name
                             )
                             if label_index is not None:
-                                self._point_label_to_position[label_index] = point_pos
+                                self._point_label_to_position[idx][label_index] = point_pos
 
                 self.categories.append(cat)
 
@@ -571,9 +572,9 @@ class _KeypointsExporter(_InstancesExporter):
         if any(element.label is not None for element in ann.elements):
             # ... arrange them in order corresponding to
             # the order of those labels in the skeleton.
-            elements = [None] * len(self._point_label_to_position)
+            elements = [None] * len(self._point_label_to_position[ann.label])
             for element in ann.elements:
-                elements[self._point_label_to_position[element.label]] = element
+                elements[self._point_label_to_position[ann.label][element.label]] = element
         else:
             # otherwise, keep the order as-is.
             elements = ann.elements

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -1866,6 +1866,35 @@ class CocoExporterTest(TestCase):
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_keypoints_in_skeleton_order_when_some_points_absent(self):
+        categories = {
+            AnnotationType.label: LabelCategories.from_iterable(
+                [
+                    "skeleton1",
+                    "skeleton2",
+                    ("alpha", "skeleton1"),
+                    ("beta", "skeleton1"),
+                    ("gamma", "skeleton1"),
+                    ("delta", "skeleton1"),
+                    ("sub1", "skeleton2"),
+                    ("sub2", "skeleton2"),
+                    ("sub3", "skeleton2"),
+                    ("sub4", "skeleton2"),
+                    ("sub5", "skeleton2"),
+                    ("sub6", "skeleton2"),
+                ]
+            ),
+            AnnotationType.points: PointsCategories.from_iterable(
+                [
+                    (0, ["alpha", "beta", "gamma", "delta"], [[0, 1], [1, 2], [2, 3]]),
+                    (
+                        1,
+                        ["sub1", "sub2", "sub3", "sub4", "sub5", "sub6"],
+                        [[0, 1], [1, 2], [2, 3], [3, 4], [5, 6]],
+                    ),
+                ]
+            ),
+        }
+
         source_dataset = Dataset.from_iterable(
             [
                 DatasetItem(
@@ -1875,34 +1904,28 @@ class CocoExporterTest(TestCase):
                     annotations=[
                         Skeleton(
                             [
-                                Points([0, 2], [1], label=2),
-                                Points([4, 1], [2], label=4),
-                                Points([2, 3], [2], label=1),
+                                Points([0, 2], [Points.Visibility.hidden.value], label=3),
+                                Points([4, 1], [Points.Visibility.visible.value], label=5),
+                                Points([2, 3], [Points.Visibility.visible.value], label=2),
                             ],
                             label=0,
                             group=1,
                             id=1,
                         ),
                         Bbox(0, 1, 4, 2, label=0, group=1, id=1),
+                        Skeleton(
+                            [
+                                Points([3, 4], [Points.Visibility.visible.value], label=8),
+                            ],
+                            label=1,
+                            group=2,
+                            id=2,
+                        ),
+                        Bbox(0, 1, 5, 3, label=1, group=2, id=2),
                     ],
                 ),
             ],
-            categories={
-                AnnotationType.label: LabelCategories.from_iterable(
-                    [
-                        "obj",
-                        ("alpha", "obj"),
-                        ("beta", "obj"),
-                        ("gamma", "obj"),
-                        ("delta", "obj"),
-                    ]
-                ),
-                AnnotationType.points: PointsCategories.from_iterable(
-                    [
-                        (0, ["alpha", "beta", "gamma", "delta"], [[0, 1], [1, 2], [2, 3]]),
-                    ]
-                ),
-            },
+            categories=categories,
         )
 
         target_dataset = Dataset.from_iterable(
@@ -1916,10 +1939,10 @@ class CocoExporterTest(TestCase):
                             [
                                 # The points will be reordered to skeleton order,
                                 # since the format doesn't preserve the original order.
-                                Points([2, 3], [2], label=1),
-                                Points([0, 2], [1], label=2),
-                                Points([0, 0], [0], label=3),
-                                Points([4, 1], [2], label=4),
+                                Points([2, 3], [Points.Visibility.visible.value], label=2),
+                                Points([0, 2], [Points.Visibility.hidden.value], label=3),
+                                Points([0, 0], [Points.Visibility.absent.value], label=4),
+                                Points([4, 1], [Points.Visibility.visible.value], label=5),
                             ],
                             label=0,
                             group=1,
@@ -1927,26 +1950,28 @@ class CocoExporterTest(TestCase):
                             attributes={"is_crowd": False},
                         ),
                         Bbox(0, 1, 4, 2, label=0, group=1, id=1, attributes={"is_crowd": False}),
+                        Skeleton(
+                            [
+                                # The points will be reordered to skeleton order,
+                                # since the format doesn't preserve the original order.
+                                Points([0, 0], [Points.Visibility.absent.value], label=6),
+                                Points([0, 0], [Points.Visibility.absent.value], label=7),
+                                Points([3, 4], [Points.Visibility.visible.value], label=8),
+                                Points([0, 0], [Points.Visibility.absent.value], label=9),
+                                Points([0, 0], [Points.Visibility.absent.value], label=10),
+                                Points([0, 0], [Points.Visibility.absent.value], label=11),
+                            ],
+                            label=1,
+                            group=2,
+                            id=2,
+                            attributes={"is_crowd": False},
+                        ),
+                        Bbox(0, 1, 5, 3, label=1, group=2, id=2, attributes={"is_crowd": False}),
                     ],
                     attributes={"id": 1},
                 ),
             ],
-            categories={
-                AnnotationType.label: LabelCategories.from_iterable(
-                    [
-                        "obj",
-                        ("alpha", "obj"),
-                        ("beta", "obj"),
-                        ("gamma", "obj"),
-                        ("delta", "obj"),
-                    ]
-                ),
-                AnnotationType.points: PointsCategories.from_iterable(
-                    [
-                        (0, ["alpha", "beta", "gamma", "delta"], [[0, 1], [1, 2], [2, 3]]),
-                    ]
-                ),
-            },
+            categories=categories,
         )
 
         with TestDir() as test_dir:

--- a/tests/unit/test_coco_format.py
+++ b/tests/unit/test_coco_format.py
@@ -1865,6 +1865,99 @@ class CocoExporterTest(TestCase):
             )
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_keypoints_in_skeleton_order_when_some_points_absent(self):
+        source_dataset = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id=1,
+                    subset="train",
+                    media=Image.from_numpy(data=np.zeros((5, 5, 3))),
+                    annotations=[
+                        Skeleton(
+                            [
+                                Points([0, 2], [1], label=2),
+                                Points([4, 1], [2], label=4),
+                                Points([2, 3], [2], label=1),
+                            ],
+                            label=0,
+                            group=1,
+                            id=1,
+                        ),
+                        Bbox(0, 1, 4, 2, label=0, group=1, id=1),
+                    ],
+                ),
+            ],
+            categories={
+                AnnotationType.label: LabelCategories.from_iterable(
+                    [
+                        "obj",
+                        ("alpha", "obj"),
+                        ("beta", "obj"),
+                        ("gamma", "obj"),
+                        ("delta", "obj"),
+                    ]
+                ),
+                AnnotationType.points: PointsCategories.from_iterable(
+                    [
+                        (0, ["alpha", "beta", "gamma", "delta"], [[0, 1], [1, 2], [2, 3]]),
+                    ]
+                ),
+            },
+        )
+
+        target_dataset = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id=1,
+                    subset="train",
+                    media=Image.from_numpy(data=np.zeros((5, 5, 3))),
+                    annotations=[
+                        Skeleton(
+                            [
+                                # The points will be reordered to skeleton order,
+                                # since the format doesn't preserve the original order.
+                                Points([2, 3], [2], label=1),
+                                Points([0, 2], [1], label=2),
+                                Points([0, 0], [0], label=3),
+                                Points([4, 1], [2], label=4),
+                            ],
+                            label=0,
+                            group=1,
+                            id=1,
+                            attributes={"is_crowd": False},
+                        ),
+                        Bbox(0, 1, 4, 2, label=0, group=1, id=1, attributes={"is_crowd": False}),
+                    ],
+                    attributes={"id": 1},
+                ),
+            ],
+            categories={
+                AnnotationType.label: LabelCategories.from_iterable(
+                    [
+                        "obj",
+                        ("alpha", "obj"),
+                        ("beta", "obj"),
+                        ("gamma", "obj"),
+                        ("delta", "obj"),
+                    ]
+                ),
+                AnnotationType.points: PointsCategories.from_iterable(
+                    [
+                        (0, ["alpha", "beta", "gamma", "delta"], [[0, 1], [1, 2], [2, 3]]),
+                    ]
+                ),
+            },
+        )
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(
+                source_dataset,
+                CocoPersonKeypointsExporter.convert,
+                test_dir,
+                target_dataset=target_dataset,
+            )
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_save_keypoints_in_skeleton_order(self):
         source_dataset = Dataset.from_iterable(
             [


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Fixed COCO keypoint export in cases there are missing skeleton elements in annotations

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
