### PR TITLE
Streaming export for MOT, LabelMe, Cityscapes; Streaming import for Cityscapes

### DIFF
--- a/src/datumaro/__init__.py
+++ b/src/datumaro/__init__.py
@@ -34,7 +34,7 @@ from .components.annotation import (
 )
 from .components.cli_plugin import CliPlugin
 from .components.contexts.importer import FailingImportErrorPolicy, ImportErrorPolicy
-from .components.dataset import Dataset, DatasetSubset, IDataset, eager_mode
+from .components.dataset import Dataset, DatasetSubset, IDataset, StreamDataset, eager_mode
 from .components.dataset_base import CategoriesInfo, DatasetBase, DatasetItem, SubsetBase
 from .components.dataset_item_storage import ItemStatus
 from .components.dataset_storage import DatasetPatch

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -10,6 +10,7 @@ import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum, auto
+from functools import partial
 from typing import List, Optional
 
 import numpy as np
@@ -20,7 +21,7 @@ from datumaro.components.annotation import (
     ExtractedMask,
     LabelCategories,
     MaskCategories,
-    RgbColor,
+    RgbColor, Annotation,
 )
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem, SubsetBase
 from datumaro.components.dataset_item_storage import ItemStatus
@@ -657,3 +658,7 @@ class CityscapesExporter(Exporter):
             )
             if osp.isdir(img_dir) and not os.listdir(img_dir):
                 os.rmdir(img_dir)
+
+    @property
+    def can_stream(self) -> bool:
+        return True

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -323,8 +323,10 @@ class CityscapesBase(SubsetBase):
             self._path, use_train_label_map=mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
         )
 
-    def _mask_path_to_annotations(self, mask_path: str) -> list[Annotation]:
+    def _mask_path_to_annotations(self, mask_path: Optional[str]) -> list[Annotation]:
         anns = []
+        if not mask_path:
+            return anns
         instances_mask = lazy_image(mask_path, dtype=np.int32)
         segm_ids = np.unique(instances_mask())
         for segm_id in segm_ids:
@@ -351,14 +353,11 @@ class CityscapesBase(SubsetBase):
 
     def __iter__(self):
         for item_id, (image_path, mask_path) in self._image_mask_path_by_id.items():
-            image = Image.from_file(path=image_path) if image_path else None
-            annotations = partial(self._mask_path_to_annotations, mask_path) if mask_path else []
-
             yield DatasetItem(
                 id=item_id,
                 subset=self._subset,
-                media=image,
-                annotations=annotations,
+                media=Image.from_file(path=image_path) if image_path else None,
+                annotations=partial(self._mask_path_to_annotations, mask_path),
             )
 
     def __len__(self):

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -309,6 +309,9 @@ class CityscapesBase(SubsetBase):
             )
             mask_suffix = CityscapesPath.GT_INSTANCE_MASK_SUFFIX
 
+        if masks:
+            self._ann_types.add(AnnotationType.mask)
+
         self._image_mask_path_by_id = {}
         for mask_path in masks:
             item_id = self._get_id_from_mask_path(mask_path, mask_suffix)
@@ -348,7 +351,6 @@ class CityscapesBase(SubsetBase):
                     attributes={"is_crowd": is_crowd},
                 )
             )
-            self._ann_types.add(AnnotationType.mask)
         return anns
 
     def __iter__(self):

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -254,16 +254,13 @@ class CityscapesBase(SubsetBase):
             images_dir = path
             annotations_dir = osp.join(self._path, CityscapesPath.GT_FINE_DIR, subset)
 
+        self._subset = subset
         self._images_dir = images_dir
         self._gt_anns_dir = annotations_dir
 
         super().__init__(subset=subset, ctx=ctx)
 
-        self._find_masks()
-        self._categories = self._load_categories(
-            self._path,
-            use_train_label_map=self._mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX,
-        )
+        self._find_item_paths()
 
     def _load_categories(self, path, use_train_label_map=False):
         label_map = None
@@ -291,20 +288,7 @@ class CityscapesBase(SubsetBase):
     def _get_id_from_mask_path(self, path, suffix):
         return osp.relpath(path, self._gt_anns_dir).replace(suffix, "")
 
-    def _find_masks(self):
-        self._masks = glob.glob(
-            osp.join(self._gt_anns_dir, "**", f"*{CityscapesPath.LABEL_TRAIN_IDS_SUFFIX}"),
-            recursive=True,
-        )
-        self._mask_suffix = CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
-        if not self._masks:
-            self._masks = glob.glob(
-                osp.join(self._gt_anns_dir, "**", f"*{CityscapesPath.GT_INSTANCE_MASK_SUFFIX}"),
-                recursive=True,
-            )
-            self._mask_suffix = CityscapesPath.GT_INSTANCE_MASK_SUFFIX
-
-    def __iter__(self):
+    def _find_item_paths(self):
         image_path_by_id = {}
 
         if self._images_dir:
@@ -313,22 +297,32 @@ class CityscapesBase(SubsetBase):
                 for p in find_images(self._images_dir, recursive=True)
             }
 
-        for mask_path in self._masks:
-            item_id = self._get_id_from_mask_path(mask_path, self._mask_suffix)
+        masks = glob.glob(
+            osp.join(self._gt_anns_dir, "**", f"*{CityscapesPath.LABEL_TRAIN_IDS_SUFFIX}"),
+            recursive=True,
+        )
+        mask_suffix = CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
+        if not masks:
+            masks = glob.glob(
+                osp.join(self._gt_anns_dir, "**", f"*{CityscapesPath.GT_INSTANCE_MASK_SUFFIX}"),
+                recursive=True,
+            )
+            mask_suffix = CityscapesPath.GT_INSTANCE_MASK_SUFFIX
+
+        self._image_mask_path_by_id = {}
+        for mask_path in masks:
+            item_id = self._get_id_from_mask_path(mask_path, mask_suffix)
 
             image = image_path_by_id.pop(item_id, None)
-            if image:
-                image = Image.from_file(path=image)
-
-            yield DatasetItem(
-                id=item_id,
-                subset=self._subset,
-                media=image,
-                annotations=partial(self._mask_path_to_annotations, mask_path),
-            )
+            self._image_mask_path_by_id[item_id] = (image, mask_path)
 
         for item_id, path in image_path_by_id.items():
-            yield DatasetItem(id=item_id, subset=self._subset, media=Image.from_file(path=path))
+            self._image_mask_path_by_id[item_id] = (path, None)
+
+        self._categories = self._load_categories(
+            self._path,
+            use_train_label_map=mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX,
+        )
 
     def _mask_path_to_annotations(self, mask_path: str) -> list[Annotation]:
         anns = []
@@ -355,6 +349,21 @@ class CityscapesBase(SubsetBase):
             )
             self._ann_types.add(AnnotationType.mask)
         return anns
+
+    def __iter__(self):
+        for item_id, (image_path, mask_path) in self._image_mask_path_by_id.items():
+            image = Image.from_file(path=image_path) if image_path else None
+            annotations = partial(self._mask_path_to_annotations, mask_path) if mask_path else []
+
+            yield DatasetItem(
+                id=item_id,
+                subset=self._subset,
+                media=image,
+                annotations=annotations,
+            )
+
+    def __len__(self):
+        return len(self._image_mask_path_by_id)
 
     @property
     def is_stream(self) -> bool:

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -1,15 +1,16 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 # Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 
+import errno
 import glob
 import logging as log
 import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum, auto
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -23,10 +24,10 @@ from datumaro.components.annotation import (
 )
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem, SubsetBase
 from datumaro.components.dataset_item_storage import ItemStatus
-from datumaro.components.errors import MediaTypeError
+from datumaro.components.errors import AnnotationExportError, InvalidAnnotationError, MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import find
 from datumaro.util.annotation_util import make_label_id_mapping
@@ -210,7 +211,7 @@ def parse_label_map(path):
                 color = None
 
             if name in label_map:
-                raise ValueError("Label '%s' is already defined" % name)
+                raise InvalidAnnotationError("Label '%s' is already defined" % name)
 
             label_map[name] = color
     return label_map
@@ -227,7 +228,13 @@ def write_label_map(path, label_map):
 
 
 class CityscapesBase(SubsetBase):
-    def __init__(self, path, subset=None):
+    def __init__(
+        self,
+        path: str,
+        *,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
         assert osp.isdir(path), path
 
         if not subset:
@@ -244,11 +251,14 @@ class CityscapesBase(SubsetBase):
             images_dir = path
             annotations_dir = osp.join(self._path, CityscapesPath.GT_FINE_DIR, subset)
 
-        self._subset = subset
         self._images_dir = images_dir
         self._gt_anns_dir = annotations_dir
 
-        super().__init__(subset=subset)
+        for path in [self._images_dir, self._gt_anns_dir]:
+            if not osp.isdir(path):
+                raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
+
+        super().__init__(subset=subset, ctx=ctx)
 
         self._items = list(self._load_items().values())
 
@@ -299,6 +309,11 @@ class CityscapesBase(SubsetBase):
                 recursive=True,
             )
             mask_suffix = CityscapesPath.GT_INSTANCE_MASK_SUFFIX
+
+        self._categories = self._load_categories(
+            self._path, use_train_label_map=mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
+        )
+
         for mask_path in masks:
             item_id = self._get_id_from_mask_path(mask_path, mask_suffix)
 
@@ -324,6 +339,7 @@ class CityscapesBase(SubsetBase):
                         attributes={"is_crowd": is_crowd},
                     )
                 )
+                self._ann_types.add(AnnotationType.mask)
 
             image = image_path_by_id.pop(item_id, None)
             if image:
@@ -338,9 +354,6 @@ class CityscapesBase(SubsetBase):
                 id=item_id, subset=self._subset, media=Image.from_file(path=path)
             )
 
-        self._categories = self._load_categories(
-            self._path, use_train_label_map=mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
-        )
         return items
 
 
@@ -374,6 +387,18 @@ class CityscapesImporter(Importer):
             )
 
         return sources
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return list(
+            {
+                osp.splitext(p)[1]
+                for p in (
+                    CityscapesPath.GT_INSTANCE_MASK_SUFFIX,
+                    CityscapesPath.LABEL_TRAIN_IDS_SUFFIX,
+                )
+            }
+        )
 
 
 class LabelmapType(Enum):
@@ -416,18 +441,27 @@ class CityscapesExporter(Exporter):
             label_map = LabelmapType.source.name
         self._load_categories(label_map)
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
         os.makedirs(self._save_dir, exist_ok=True)
 
         for subset_name, subset in self._extractor.subsets().items():
+            media_dir = osp.join(
+                self._save_dir,
+                CityscapesPath.IMGS_FINE_DIR,
+                CityscapesPath.ORIGINAL_IMAGE_DIR,
+                subset_name,
+            )
+            os.makedirs(media_dir, exist_ok=True)
+
+            mask_dir = osp.join(self._save_dir, CityscapesPath.GT_FINE_DIR, subset_name)
+            os.makedirs(mask_dir, exist_ok=True)
+
             for item in subset:
                 image_path = osp.join(
-                    CityscapesPath.IMGS_FINE_DIR,
-                    CityscapesPath.ORIGINAL_IMAGE_DIR,
-                    subset_name,
+                    media_dir,
                     item.id + CityscapesPath.ORIGINAL_IMAGE + self._find_image_ext(item),
                 )
                 if self._save_media:
@@ -453,7 +487,6 @@ class CityscapesExporter(Exporter):
                     background_label_id=0,
                 )
 
-                mask_dir = osp.join(self._save_dir, CityscapesPath.GT_FINE_DIR, subset_name)
                 mask_name = item.id + "_" + CityscapesPath.GT_FINE_DIR
 
                 color_mask_path = osp.join(mask_dir, mask_name + CityscapesPath.COLOR_IMAGE)
@@ -519,7 +552,7 @@ class CityscapesExporter(Exporter):
                 label_map = parse_label_map(label_map_source)
 
         else:
-            raise Exception(
+            raise AnnotationExportError(
                 "Wrong labelmap specified, "
                 "expected one of %s or a file path" % ", ".join(t.name for t in LabelmapType)
             )

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -3,18 +3,19 @@
 #
 # SPDX-License-Identifier: MIT
 
-import errno
 import glob
 import logging as log
 import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum, auto
+from functools import partial
 from typing import List, Optional
 
 import numpy as np
 
 from datumaro.components.annotation import (
+    Annotation,
     AnnotationType,
     CompiledMask,
     ExtractedMask,
@@ -29,6 +30,7 @@ from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
 from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
+from datumaro.components.merge.extractor_merger import ExtractorMerger
 from datumaro.util import find
 from datumaro.util.annotation_util import make_label_id_mapping
 from datumaro.util.image import find_images, lazy_image, save_image
@@ -234,6 +236,7 @@ class CityscapesBase(SubsetBase):
         *,
         subset: Optional[str] = None,
         ctx: Optional[ImportContext] = None,
+        stream: bool = True,
     ):
         assert osp.isdir(path), path
 
@@ -254,13 +257,13 @@ class CityscapesBase(SubsetBase):
         self._images_dir = images_dir
         self._gt_anns_dir = annotations_dir
 
-        for path in [self._images_dir, self._gt_anns_dir]:
-            if not osp.isdir(path):
-                raise NotADirectoryError(errno.ENOTDIR, "Can't find dataset directory", path)
-
         super().__init__(subset=subset, ctx=ctx)
 
-        self._items = list(self._load_items().values())
+        self._find_masks()
+        self._categories = self._load_categories(
+            self._path,
+            use_train_label_map=self._mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX,
+        )
 
     def _load_categories(self, path, use_train_label_map=False):
         label_map = None
@@ -288,8 +291,20 @@ class CityscapesBase(SubsetBase):
     def _get_id_from_mask_path(self, path, suffix):
         return osp.relpath(path, self._gt_anns_dir).replace(suffix, "")
 
-    def _load_items(self):
-        items = {}
+    def _find_masks(self):
+        self._masks = glob.glob(
+            osp.join(self._gt_anns_dir, "**", f"*{CityscapesPath.LABEL_TRAIN_IDS_SUFFIX}"),
+            recursive=True,
+        )
+        self._mask_suffix = CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
+        if not self._masks:
+            self._masks = glob.glob(
+                osp.join(self._gt_anns_dir, "**", f"*{CityscapesPath.GT_INSTANCE_MASK_SUFFIX}"),
+                recursive=True,
+            )
+            self._mask_suffix = CityscapesPath.GT_INSTANCE_MASK_SUFFIX
+
+    def __iter__(self):
         image_path_by_id = {}
 
         if self._images_dir:
@@ -298,63 +313,52 @@ class CityscapesBase(SubsetBase):
                 for p in find_images(self._images_dir, recursive=True)
             }
 
-        masks = glob.glob(
-            osp.join(self._gt_anns_dir, "**", f"*{CityscapesPath.LABEL_TRAIN_IDS_SUFFIX}"),
-            recursive=True,
-        )
-        mask_suffix = CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
-        if not masks:
-            masks = glob.glob(
-                osp.join(self._gt_anns_dir, "**", f"*{CityscapesPath.GT_INSTANCE_MASK_SUFFIX}"),
-                recursive=True,
-            )
-            mask_suffix = CityscapesPath.GT_INSTANCE_MASK_SUFFIX
-
-        self._categories = self._load_categories(
-            self._path, use_train_label_map=mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
-        )
-
-        for mask_path in masks:
-            item_id = self._get_id_from_mask_path(mask_path, mask_suffix)
-
-            anns = []
-            instances_mask = lazy_image(mask_path, dtype=np.int32)
-            segm_ids = np.unique(instances_mask())
-            for segm_id in segm_ids:
-                # either is_crowd or ann_id should be set
-                if segm_id < 1000:
-                    label_id = segm_id
-                    is_crowd = True
-                    ann_id = None
-                else:
-                    label_id = segm_id // 1000
-                    is_crowd = False
-                    ann_id = segm_id % 1000
-                anns.append(
-                    ExtractedMask(
-                        index_mask=instances_mask,
-                        index=segm_id,
-                        label=label_id,
-                        id=ann_id,
-                        attributes={"is_crowd": is_crowd},
-                    )
-                )
-                self._ann_types.add(AnnotationType.mask)
+        for mask_path in self._masks:
+            item_id = self._get_id_from_mask_path(mask_path, self._mask_suffix)
 
             image = image_path_by_id.pop(item_id, None)
             if image:
                 image = Image.from_file(path=image)
 
-            items[item_id] = DatasetItem(
-                id=item_id, subset=self._subset, media=image, annotations=anns
+            yield DatasetItem(
+                id=item_id,
+                subset=self._subset,
+                media=image,
+                annotations=partial(self._mask_path_to_annotations, mask_path),
             )
 
         for item_id, path in image_path_by_id.items():
-            items[item_id] = DatasetItem(
-                id=item_id, subset=self._subset, media=Image.from_file(path=path)
-            )
+            yield DatasetItem(id=item_id, subset=self._subset, media=Image.from_file(path=path))
 
-        return items
+    def _mask_path_to_annotations(self, mask_path: str) -> list[Annotation]:
+        anns = []
+        instances_mask = lazy_image(mask_path, dtype=np.int32)
+        segm_ids = np.unique(instances_mask())
+        for segm_id in segm_ids:
+            # either is_crowd or ann_id should be set
+            if segm_id < 1000:
+                label_id = segm_id
+                is_crowd = True
+                ann_id = None
+            else:
+                label_id = segm_id // 1000
+                is_crowd = False
+                ann_id = segm_id % 1000
+            anns.append(
+                ExtractedMask(
+                    index_mask=instances_mask,
+                    index=segm_id,
+                    label=label_id,
+                    id=ann_id,
+                    attributes={"is_crowd": is_crowd},
+                )
+            )
+            self._ann_types.add(AnnotationType.mask)
+        return anns
+
+    @property
+    def is_stream(self) -> bool:
+        return True
 
 
 class CityscapesImporter(Importer):
@@ -399,6 +403,13 @@ class CityscapesImporter(Importer):
                 )
             }
         )
+
+    @property
+    def can_stream(self) -> bool:
+        return True
+
+    def get_extractor_merger(self):
+        return ExtractorMerger
 
 
 class LabelmapType(Enum):

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -320,8 +320,7 @@ class CityscapesBase(SubsetBase):
             self._image_mask_path_by_id[item_id] = (path, None)
 
         self._categories = self._load_categories(
-            self._path,
-            use_train_label_map=mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX,
+            self._path, use_train_label_map=mask_suffix is CityscapesPath.LABEL_TRAIN_IDS_SUFFIX
         )
 
     def _mask_path_to_annotations(self, mask_path: str) -> list[Annotation]:

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -10,7 +10,6 @@ import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum, auto
-from functools import partial
 from typing import List, Optional
 
 import numpy as np
@@ -21,7 +20,7 @@ from datumaro.components.annotation import (
     ExtractedMask,
     LabelCategories,
     MaskCategories,
-    RgbColor, Annotation,
+    RgbColor,
 )
 from datumaro.components.dataset_base import CategoriesInfo, DatasetItem, SubsetBase
 from datumaro.components.dataset_item_storage import ItemStatus

--- a/src/datumaro/plugins/data_formats/labelme.py
+++ b/src/datumaro/plugins/data_formats/labelme.py
@@ -6,6 +6,7 @@ import logging as log
 import os
 import os.path as osp
 from collections import defaultdict
+from functools import partial
 from glob import glob, iglob
 from typing import List, Optional
 
@@ -233,8 +234,11 @@ class LabelMeBase(DatasetBase):
                 )
                 if not osp.isfile(mask_path):
                     raise Exception("Can't find mask at '%s'" % mask_path)
-                mask = load_mask(mask_path)
-                mask = np.any(mask, axis=2)
+
+                def _lazy_mask(path: str):
+                    return np.any(load_mask(path), axis=2)
+
+                mask = partial(_lazy_mask, mask_path)
                 ann_items.append(Mask(image=mask, label=label, id=obj_id, attributes=attributes))
 
             if not deleted:

--- a/src/datumaro/plugins/data_formats/labelme.py
+++ b/src/datumaro/plugins/data_formats/labelme.py
@@ -7,6 +7,7 @@ import os
 import os.path as osp
 from collections import defaultdict
 from glob import glob, iglob
+from typing import List, Optional
 
 import numpy as np
 from defusedxml import ElementTree
@@ -16,7 +17,7 @@ from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import cast, escape, unescape
 from datumaro.util.image import save_image
@@ -44,9 +45,9 @@ class LabelMePath:
 
 
 class LabelMeBase(DatasetBase):
-    def __init__(self, path):
+    def __init__(self, path: str, *, ctx: Optional[ImportContext] = None):
         assert osp.isdir(path), path
-        super().__init__()
+        super().__init__(ctx=ctx)
 
         self._items, self._categories, self._subsets = self._parse(path)
         self._length = len(self._items)
@@ -299,9 +300,11 @@ class LabelMeBase(DatasetBase):
 
 
 class LabelMeImporter(Importer):
+    _ANNO_EXT = ".xml"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        annot_paths = context.require_files("**/*.xml")
+        annot_paths = context.require_files(f"**/*{cls._ANNO_EXT}")
 
         for annot_path in annot_paths:
             with context.probe_text_file(
@@ -356,11 +359,15 @@ class LabelMeImporter(Importer):
             pass
         return subsets
 
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
+
 
 class LabelMeExporter(Exporter):
     DEFAULT_IMAGE_EXT = LabelMePath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         if self._extractor.media_type() and not issubclass(self._extractor.media_type(), Image):
             raise MediaTypeError("Media type is not an image")
 
@@ -519,3 +526,7 @@ class LabelMeExporter(Exporter):
     def _paint_mask(mask):
         # TODO: check if mask colors are random
         return np.array([[0, 0, 0, 0], [255, 203, 0, 153]], dtype=np.uint8)[mask.astype(np.uint8)]
+
+    @property
+    def can_stream(self) -> bool:
+        return True

--- a/src/datumaro/plugins/data_formats/mot.py
+++ b/src/datumaro/plugins/data_formats/mot.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
+# Copyright (C) 2022 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/datumaro/plugins/data_formats/mot.py
+++ b/src/datumaro/plugins/data_formats/mot.py
@@ -1,5 +1,4 @@
-# Copyright (C) 2020-2021 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) 2020-2023 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -13,13 +12,14 @@ import os
 import os.path as osp
 from collections import OrderedDict
 from enum import Enum
+from typing import List, Optional, Union
 
 from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories
 from datumaro.components.dataset_base import DatasetItem, SubsetBase
 from datumaro.components.errors import MediaTypeError
 from datumaro.components.exporter import Exporter
 from datumaro.components.format_detection import FormatDetectionContext
-from datumaro.components.importer import Importer
+from datumaro.components.importer import ImportContext, Importer
 from datumaro.components.media import Image
 from datumaro.util import cast
 from datumaro.util.image import find_images
@@ -67,8 +67,17 @@ class MotPath:
 
 
 class MotSeqBase(SubsetBase):
-    def __init__(self, path, labels=None, occlusion_threshold=0, is_gt=None, subset=None):
-        super().__init__(subset=subset)
+    def __init__(
+        self,
+        path: str,
+        *,
+        labels: Optional[Union[str, List[str]]] = None,
+        occlusion_threshold: float = 0.0,
+        is_gt: Optional[bool] = None,
+        subset: Optional[str] = None,
+        ctx: Optional[ImportContext] = None,
+    ):
+        super().__init__(subset=subset, ctx=ctx)
 
         assert osp.isfile(path)
         seq_root = osp.dirname(osp.dirname(path))
@@ -191,6 +200,7 @@ class MotSeqBase(SubsetBase):
                     attributes["score"] = float(confidence)
 
                 annotations.append(Bbox(x, y, w, h, label=label_id, attributes=attributes))
+                self._ann_types.add(AnnotationType.bbox)
 
                 items[frame_id] = item
         return items
@@ -222,21 +232,31 @@ class MotSeqBase(SubsetBase):
 
 
 class MotSeqImporter(Importer):
+    _ANNO_EXT = ".txt"
+
     @classmethod
     def detect(cls, context: FormatDetectionContext) -> None:
-        context.require_file("gt/gt.txt")
+        context.require_file(f"gt/gt{cls._ANNO_EXT}")
 
     @classmethod
     def find_sources(cls, path):
         return cls._find_sources_recursive(
-            path, ".txt", "mot_seq", dirname="gt", filename=osp.splitext(MotPath.GT_FILENAME)[0]
+            path,
+            cls._ANNO_EXT,
+            "mot_seq",
+            dirname="gt",
+            filename=osp.splitext(MotPath.GT_FILENAME)[0],
         )
+
+    @classmethod
+    def get_file_extensions(cls) -> List[str]:
+        return [cls._ANNO_EXT]
 
 
 class MotSeqGtExporter(Exporter):
     DEFAULT_IMAGE_EXT = MotPath.IMAGE_EXT
 
-    def apply(self):
+    def _apply_impl(self):
         extractor = self._extractor
 
         if extractor.media_type() and not issubclass(extractor.media_type(), Image):

--- a/src/datumaro/plugins/data_formats/mot.py
+++ b/src/datumaro/plugins/data_formats/mot.py
@@ -316,3 +316,7 @@ class MotSeqGtExporter(Exporter):
             labels_file = osp.join(anno_dir, MotPath.LABELS_FILE)
             with open(labels_file, "w", encoding="utf-8") as f:
                 f.write("\n".join(l.name for l in extractor.categories()[AnnotationType.label]))
+
+    @property
+    def can_stream(self) -> bool:
+        return True

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -158,7 +158,7 @@ def test_streaming_importers(test_dir, export_format, fxt_dataset):
 
         # annotations are not parsed if we do not access them
         items = list(iter(parsed_dataset))
-        assert all(not item.annotations_are_initialized for item in items)
+        assert all(not (item.annotations_are_initialized and item.annotations) for item in items)
         del items
 
         for item in parsed_dataset:
@@ -185,7 +185,7 @@ def test_streaming_importers(test_dir, export_format, fxt_dataset):
             assert subset.is_stream
             for item in subset:
                 # annotations are not parsed if we do not access them
-                assert not item.annotations_are_initialized
+                assert not (item.annotations_are_initialized and item.annotations)
                 # annotations are parsed if we access them
                 assert isinstance(item.annotations, Annotations)
                 assert item.annotations_are_initialized

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -148,6 +148,8 @@ def test_streaming_importers(test_dir, export_format, fxt_dataset):
         parsed_dataset = StreamDataset.import_from(dataset_folder, format=import_format)
         assert parsed_dataset.is_stream
 
+        assert len(parsed_dataset._data._source) == len(fxt_dataset)
+
         # nothing initialized yet (except for datumaro format
         # which needs to init some (not all) items to determine media type)
         if import_format == "datumaro":

--- a/tests/unit/data_formats/test_streaming_efficiency.py
+++ b/tests/unit/data_formats/test_streaming_efficiency.py
@@ -160,7 +160,7 @@ def test_streaming_importers(test_dir, export_format, fxt_dataset):
 
         # annotations are not parsed if we do not access them
         items = list(iter(parsed_dataset))
-        assert all(not (item.annotations_are_initialized and item.annotations) for item in items)
+        assert all(not item.annotations_are_initialized for item in items)
         del items
 
         for item in parsed_dataset:
@@ -187,7 +187,7 @@ def test_streaming_importers(test_dir, export_format, fxt_dataset):
             assert subset.is_stream
             for item in subset:
                 # annotations are not parsed if we do not access them
-                assert not (item.annotations_are_initialized and item.annotations)
+                assert not item.annotations_are_initialized
                 # annotations are parsed if we access them
                 assert isinstance(item.annotations, Annotations)
                 assert item.annotations_are_initialized

--- a/tests/unit/test_cityscapes_format.py
+++ b/tests/unit/test_cityscapes_format.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import datumaro.plugins.data_formats.cityscapes as Cityscapes
 from datumaro.components.annotation import AnnotationType, LabelCategories, Mask, MaskCategories
-from datumaro.components.dataset import Dataset
+from datumaro.components.dataset import Dataset, StreamDataset
 from datumaro.components.dataset_base import DatasetBase, DatasetItem
 from datumaro.components.environment import Environment
 from datumaro.components.media import Image
@@ -56,6 +56,8 @@ class CityscapesFormatTest(TestCase):
 
 
 class CityscapesImportTest(TestCase):
+    DATASET_CLS = Dataset
+
     @mark_requirement(Requirements.DATUM_267)
     def test_can_import(self):
         # is_crowd marks labels allowing to specify instance id
@@ -128,7 +130,7 @@ class CityscapesImportTest(TestCase):
             categories=Cityscapes.make_cityscapes_categories(),
         )
 
-        parsed_dataset = Dataset.import_from(DUMMY_DATASET_DIR, "cityscapes")
+        parsed_dataset = self.DATASET_CLS.import_from(DUMMY_DATASET_DIR, "cityscapes")
 
         compare_datasets(self, source_dataset, parsed_dataset)
 
@@ -176,7 +178,7 @@ class CityscapesImportTest(TestCase):
             categories=Cityscapes.make_cityscapes_categories(label_map=TRAIN_CITYSCAPES_LABEL_MAP),
         )
 
-        parsed_dataset = Dataset.import_from(DUMMY_TRAIN_DATASET_DIR, "cityscapes")
+        parsed_dataset = self.DATASET_CLS.import_from(DUMMY_TRAIN_DATASET_DIR, "cityscapes")
 
         compare_datasets(self, source_dataset, parsed_dataset)
 
@@ -184,6 +186,10 @@ class CityscapesImportTest(TestCase):
     def test_can_detect_cityscapes(self):
         detected_formats = Environment().detect_dataset(DUMMY_DATASET_DIR)
         self.assertEqual([CityscapesImporter.NAME], detected_formats)
+
+
+class CityscapesStreamImportTest(CityscapesImportTest):
+    DATASET_CLS = StreamDataset
 
 
 class TestExtractorBase(DatasetBase):
@@ -195,6 +201,8 @@ class TestExtractorBase(DatasetBase):
 
 
 class CityscapesExporterTest(TestCase):
+    STREAM = False
+
     def _test_save_and_load(
         self, source_dataset, converter, test_dir, target_dataset=None, importer_args=None, **kwargs
     ):
@@ -206,6 +214,7 @@ class CityscapesExporterTest(TestCase):
             importer="cityscapes",
             target_dataset=target_dataset,
             importer_args=importer_args,
+            stream=self.STREAM,
             **kwargs,
         )
 
@@ -957,3 +966,7 @@ class CityscapesExporterTest(TestCase):
                 partial(CityscapesExporter.convert, label_map="cityscapes"),
                 test_dir,
             )
+
+
+class CityscapesStreamExporterTest(CityscapesExporterTest):
+    STREAM = True


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Enabling export streaming for MOT, LabelMe, Cityscapes
Syncing MOT with upstream, partially syncing Cityscapes with upstream

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
