### PR TITLE
Optimizations for streaming

### DIFF
--- a/src/datumaro/components/dataset_storage.py
+++ b/src/datumaro/components/dataset_storage.py
@@ -650,7 +650,10 @@ class StreamSubset(IDataset):
 
     def __len__(self) -> int:
         if self._length is None:
-            self._length = sum(1 for _ in self)
+            if self._source.subset_names == {self._subset}:
+                self._length = len(self._source)
+            else:
+                self._length = sum(1 for _ in self)
         return self._length
 
     def subsets(self) -> Dict[str, IDataset]:
@@ -695,7 +698,7 @@ class StreamDatasetStorage(DatasetStorage):
     ):
         if not source.is_stream:
             raise ValueError("source should be a stream.")
-        self._subset_names = list(source.subsets().keys())
+        self._subset_names = set(source.subsets().keys())
         super().__init__(
             source=source,
             infos=infos,
@@ -746,7 +749,10 @@ class StreamDatasetStorage(DatasetStorage):
 
     def __len__(self) -> int:
         if self._length is None:
-            self._length = sum(1 for _ in self)
+            if not self._transforms:
+                self._length = len(self._source)
+            else:
+                self._length = sum(1 for _ in self)
         return self._length
 
     def put(self, item: DatasetItem) -> None:
@@ -764,7 +770,7 @@ class StreamDatasetStorage(DatasetStorage):
     def get_subset(self, name: str) -> IDataset:
         return self.subsets()[name]
 
-    def _collect_subset_names(self):
+    def _collect_subset_names(self) -> set[str]:
         assert not self._keeps_subsets_intact
 
         item_generator = stacked_transform = self.stacked_transform
@@ -789,7 +795,7 @@ class StreamDatasetStorage(DatasetStorage):
         return {item.subset for item in item_generator}
 
     @property
-    def subset_names(self):
+    def subset_names(self) -> set[str]:
         if self._subset_names is None:
             self._subset_names = self._collect_subset_names()
 

--- a/tests/unit/components/test_dataset_storage.py
+++ b/tests/unit/components/test_dataset_storage.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 from datumaro.components.annotation import AnnotationType
 from datumaro.components.dataset_base import CategoriesInfo, DatasetInfo
-from datumaro.components.dataset_storage import StreamDatasetStorage
+from datumaro.components.dataset_storage import StreamDatasetStorage, StreamSubset
 from datumaro.plugins.transforms import MapSubsets, RandomSplit, RemapLabels, Rename, UpdateInfos
 from datumaro.util.definitions import DEFAULT_SUBSET_NAME
 
@@ -169,3 +169,18 @@ class StreamDatasetStorageTest:
         # Check Rename
         self._test_loop(fxt_stream_extractor, storage, n_calls, id_pattern="rename_{idx}")
         assert fxt_stream_extractor.__iter__.call_count == n_calls
+
+
+class StreamSubsetTest:
+    def test_single_subset_len_uses_dataset_len(self):
+        dataset_storage_mock = MagicMock(spec=StreamDatasetStorage)
+        dataset_storage_mock.subset_names = {"FOO"}
+
+        class StreamSubsetWrap(StreamSubset):
+            def __iter__(self):
+                # should not iterate items to get length
+                assert False
+
+        subset = StreamSubsetWrap(dataset_storage_mock, "FOO")
+        len(subset)
+        assert dataset_storage_mock.__len__.called

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -2562,8 +2562,9 @@ class StreamDatasetTest:
         extractor.item_iterated_count = 0
         dataset = StreamDataset.from_extractors(extractor)
 
-        # no need to iterate items to get subsets
+        # no need to iterate items to get subsets or length
         dataset.subsets()
+        len(dataset)
         assert extractor.item_iterated_count == 0
 
         # accessing items through subsets only iterates relevant items


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

1. If StreamDatasetStorage has only one subset, it's StreamSubset should not calculate length itself and should instead use StreamDatasetStorage length
2. If StreamDatasetStorage has no transformations, it can use its source length

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
