### PR TITLE
Relax numpy requirement

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -6,7 +6,7 @@ lxml<6,>=5.2.0
 matplotlib>=3.3.1
 networkx>=2.6
 nibabel>=3.2.1
-numpy<2,>=1.22.2
+numpy<2.3,>=1.22.2
 orjson==3.10.12
 Pillow>=10.3.0
 ruamel.yaml>=0.17.0

--- a/src/datumaro/util/mask_tools.py
+++ b/src/datumaro/util/mask_tools.py
@@ -137,8 +137,8 @@ def paint_mask(mask: IndexMask, colormap=None) -> ColorMask:
     if callable(colormap):
         map_fn = colormap
     else:
-        map_fn = lambda c: colormap.get(c, (0, 0, 0))
-    palette = np.array([map_fn(c)[::-1] for c in range(256)], dtype=np.uint8)
+        map_fn = lambda c: colormap.get(c, (-1, -1, -1))
+    palette = np.mod([map_fn(c)[::-1] for c in range(256)], 256).astype(np.uint8)
 
     mask = mask.astype(np.uint8)
     painted_mask = palette[mask].reshape((*mask.shape[:2], 3))
@@ -153,7 +153,7 @@ def remap_mask(mask: ColorMask, map_fn) -> ColorMask:
     """
     check_is_mask(mask)
 
-    return np.array([max(0, map_fn(c)) for c in range(256)], dtype=np.uint8)[mask]
+    return np.mod([map_fn(c) for c in range(256)], 256).astype(np.uint8)[mask]
 
 
 def make_index_mask(

--- a/src/datumaro/util/pickle_util.py
+++ b/src/datumaro/util/pickle_util.py
@@ -9,7 +9,10 @@ import numpy.core.multiarray
 
 class RestrictedUnpickler(pickle.Unpickler):
     def find_class(self, module, name):
-        if module == "numpy.core.multiarray" and name in PickleLoader.safe_numpy:
+        if (
+            module in ["numpy.core.multiarray", "numpy._core.multiarray"]
+            and name in PickleLoader.safe_numpy
+        ):
             return getattr(numpy.core.multiarray, name)
         elif module == "numpy" and name in PickleLoader.safe_numpy:
             return getattr(numpy, name)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary
This allows to install Datumaro on Python 3.12. I took the 2.3 bound from upstream Datumaro.

Compatibility fixes are cherry-picked from https://github.com/open-edge-platform/datumaro/commit/a5b18ac.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
