### PR TITLE
Optimize ultralytics yolo classification import

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -48,6 +48,9 @@ tabulate
 # prune
 scikit-learn
 
+# Stream JSON parser
+json-stream
+
 # Stream JSON dumper
 python-rapidjson==1.20
 

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -851,11 +851,13 @@ class YoloUltralyticsClassificationBase(_YoloBase):
         return osp.join(subset_path, YoloUltralyticsClassificationFormat.LABELS_FILE)
 
     def _get_lazy_subset_items(self, subset_name: str):
-        with self.LabelsFileReader(self._get_labels_file_path(subset_name)) as reader:
-            return {
-                item_id: osp.join(subset_name, item_info["path"])
-                for item_id, item_info in reader.items()
-            }
+        labels_file_path = self._get_labels_file_path(subset_name)
+        if os.path.isfile(labels_file_path):
+            with self.LabelsFileReader(labels_file_path) as reader:
+                return {
+                    item_id: osp.join(subset_name, item_info["path"])
+                    for item_id, item_info in reader.items()
+                }
 
         subset_path = osp.join(self._path, subset_name)
         return {

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 import os
 import os.path as osp
 import re
@@ -13,6 +14,7 @@ from itertools import cycle
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import cv2
+import json_stream
 import numpy as np
 import yaml
 
@@ -790,13 +792,38 @@ class YoloUltralyticsPoseBase(YoloUltralyticsDetectionBase):
 
 
 class YoloUltralyticsClassificationBase(_YoloBase):
-    def __init__(self, rootpath, image_info=None, stream=False, **kwargs):
-        self._labels_file_cache: dict[str, dict] = {}
-        super().__init__(rootpath, image_info, stream, **kwargs)
+    class LabelsFileReader:
+        def __init__(self, path: str):
+            self.path = path
+            self.file = None
+            self.json_stream = None
 
-    def __iter__(self):
-        yield from super().__iter__()
-        self._labels_file_cache.clear()
+        def __enter__(self):
+            assert self.file is None
+            assert self.json_stream is None
+
+            try:
+                self.file = open(self.path, "rb")
+                self.json_stream = json_stream.load(self.file, persistent=False)
+                return self.json_stream
+            except Exception:
+                self.close()
+                raise
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.close()
+
+        def close(self):
+            if self.json_stream:
+                self.json_stream = None
+
+            if self.file:
+                self.file.close()
+                self.file = None
+
+    def __init__(self, rootpath, image_info = None, stream = False, **kwargs):
+        self._labels_file_reader = None
+        super().__init__(rootpath, image_info, stream, **kwargs)
 
     def _get_subset_names(self):
         return [
@@ -805,7 +832,7 @@ class YoloUltralyticsClassificationBase(_YoloBase):
             if osp.isdir(osp.join(self._path, subset_name))
         ]
 
-    def _get_image_paths_for_subset_and_label(self, subset_name: str, label_name: str) -> list[str]:
+    def _get_image_paths_for_subset_and_label(self, subset_name: str, label_name: str) -> Generator[list[str], None, None]:
         category_folder = osp.join(self._path, subset_name, label_name)
         image_list_path = osp.join(category_folder, YoloUltralyticsClassificationFormat.LABELS_FILE)
         if osp.isfile(image_list_path):
@@ -817,27 +844,24 @@ class YoloUltralyticsClassificationBase(_YoloBase):
             for image_path in find_images(category_folder, recursive=True)
         )
 
-    def _get_item_info_from_labels_file(self, subset_name: str) -> Optional[Dict]:
+    def _get_labels_file_path(self, subset_name: str) -> str:
         subset_path = osp.join(self._path, subset_name)
-        labels_file_path = osp.join(subset_path, YoloUltralyticsClassificationFormat.LABELS_FILE)
+        return osp.join(subset_path, YoloUltralyticsClassificationFormat.LABELS_FILE)
 
-        if labels_file_path in self._labels_file_cache:
-            parsed_data = self._labels_file_cache[labels_file_path]
-        else:
-            if osp.isfile(labels_file_path):
-                parsed_data = parse_json_file(labels_file_path)
-                self._labels_file_cache[labels_file_path] = parsed_data
-            else:
-                parsed_data = None
+    def _get_items_from_labels_file(self, subset_name: str) -> Optional[Dict]:
+        labels_file_path = self._get_labels_file_path(subset_name)
 
-        return parsed_data
+        if osp.isfile(labels_file_path):
+            return parse_json_file(labels_file_path)
 
     def _get_lazy_subset_items(self, subset_name: str):
+        with self.LabelsFileReader(self._get_labels_file_path(subset_name)) as reader:
+            return {
+                item_id: osp.join(subset_name, item_info["path"])
+                for item_id, item_info in reader.items()
+            }
+
         subset_path = osp.join(self._path, subset_name)
-
-        if item_info := self._get_item_info_from_labels_file(subset_name):
-            return {id: osp.join(subset_name, item_info[id]["path"]) for id in item_info}
-
         return {
             self.name_from_path(image_path): image_path
             for category_name in os.listdir(subset_path)
@@ -845,10 +869,25 @@ class YoloUltralyticsClassificationBase(_YoloBase):
             for image_path in self._get_image_paths_for_subset_and_label(subset_name, category_name)
         }
 
+    def _get_item_info_from_labels_file(self, subset_name: str, item_id: str) -> Optional[Dict]:
+        labels_file_path = self._get_labels_file_path(subset_name)
+        if not osp.isfile(labels_file_path):
+            return None
+
+        if self._labels_file_reader and self._labels_file_reader.path != labels_file_path:
+            self._labels_file_reader.close()
+            self._labels_file_reader = None
+
+        if not self._labels_file_reader:
+            self._labels_file_reader = self.LabelsFileReader(labels_file_path)
+            self._labels_file_reader.__enter__()
+
+        return self._labels_file_reader.json_stream[item_id]
+
     def _parse_annotations(self, image: Image, *, item_id: Tuple[str, str]) -> List[Annotation]:
         item_id, subset_name = item_id
-        if item_info := self._get_item_info_from_labels_file(subset_name):
-            label_names = item_info[item_id]["labels"]
+        if item_info := self._get_item_info_from_labels_file(subset_name, item_id):
+            label_names = item_info["labels"]
         else:
             subset_path = osp.join(self._path, subset_name)
             relative_image_path = osp.relpath(image.path, subset_path)
@@ -860,6 +899,19 @@ class YoloUltralyticsClassificationBase(_YoloBase):
             if label != YoloUltralyticsClassificationFormat.IMAGE_DIR_NO_LABEL
         ]
 
+    def _get_labels_from_labels_file(self, subset_name: str) -> set[str]:
+        labels_file_path = self._get_labels_file_path(subset_name)
+        labels = set()
+
+        if not osp.isfile(labels_file_path):
+            return labels
+
+        with self.LabelsFileReader(self._get_labels_file_path(subset_name)) as reader:
+            for item_info in reader.values():
+                labels.update(item_info["labels"])
+
+        return labels
+
     def _load_categories(self) -> CategoriesInfo:
         categories = set()
         for subset in os.listdir(self._path):
@@ -867,8 +919,7 @@ class YoloUltralyticsClassificationBase(_YoloBase):
             if not osp.isdir(subset_path):
                 continue
 
-            if item_info := self._get_item_info_from_labels_file(subset):
-                categories.update(*[item_info[item_id]["labels"] for item_id in item_info])
+            categories.update(self._get_labels_from_labels_file(subset))
 
             for label_dir_name in os.listdir(subset_path):
                 if not osp.isdir(osp.join(subset_path, label_dir_name)):

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import cv2
 import json_stream
+import json_stream.base
 import numpy as np
 import yaml
 
@@ -791,39 +792,47 @@ class YoloUltralyticsPoseBase(YoloUltralyticsDetectionBase):
         return skeleton
 
 
-class YoloUltralyticsClassificationBase(_YoloBase):
-    class LabelsFileReader:
-        def __init__(self, path: str):
-            self.path = path
-            self.file = None
-            self.json_stream = None
+class LabelsFileReader:
+    def __init__(self, path: str):
+        self.path = path
+        self._file = None
+        self._json_stream = None
 
-        def __enter__(self):
-            assert self.file is None
-            assert self.json_stream is None
+    def __enter__(self):
+        assert self._file is None
+        assert self._json_stream is None
 
-            try:
-                self.file = open(self.path, "rb")
-                self.json_stream = json_stream.load(self.file, persistent=False)
-                return self.json_stream
-            except Exception:
-                self.close()
-                raise
-
-        def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            self._file = open(self.path, "rb")
+            self._json_stream = json_stream.load(self._file)
+            return self._json_stream
+        except Exception:
             self.close()
+            raise
 
-        def close(self):
-            if self.json_stream:
-                self.json_stream = None
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
 
-            if self.file:
-                self.file.close()
-                self.file = None
+    def close(self):
+        if self._json_stream:
+            self._json_stream = None
 
+        if self._file:
+            self._file.close()
+            self._file = None
+
+
+class YoloUltralyticsClassificationBase(_YoloBase):
     def __init__(self, rootpath, image_info=None, stream=False, **kwargs):
-        self._labels_file_reader = None
+        self._labels_file_reader: LabelsFileReader | None = None
         super().__init__(rootpath, image_info, stream, **kwargs)
+
+    def __iter__(self):
+        yield from super().__iter__()
+
+        if self._labels_file_reader:
+            self._labels_file_reader.close()
+            self._labels_file_reader = None
 
     def _get_subset_names(self):
         return [
@@ -853,7 +862,7 @@ class YoloUltralyticsClassificationBase(_YoloBase):
     def _get_lazy_subset_items(self, subset_name: str):
         labels_file_path = self._get_labels_file_path(subset_name)
         if os.path.isfile(labels_file_path):
-            with self.LabelsFileReader(labels_file_path) as reader:
+            with LabelsFileReader(labels_file_path) as reader:
                 return {
                     item_id: osp.join(subset_name, item_info["path"])
                     for item_id, item_info in reader.items()
@@ -867,20 +876,30 @@ class YoloUltralyticsClassificationBase(_YoloBase):
             for image_path in self._get_image_paths_for_subset_and_label(subset_name, category_name)
         }
 
-    def _get_item_info_from_labels_file(self, subset_name: str, item_id: str) -> Optional[Dict]:
+    def _get_item_info_from_labels_file(self, subset_name: str, item_id: str) -> dict | None:
         labels_file_path = self._get_labels_file_path(subset_name)
         if not osp.isfile(labels_file_path):
             return None
 
-        if self._labels_file_reader and self._labels_file_reader.path != labels_file_path:
+        def _parse_item():
+            if self._labels_file_reader and self._labels_file_reader.path != labels_file_path:
+                self._labels_file_reader.close()
+                self._labels_file_reader = None
+
+            if not self._labels_file_reader:
+                self._labels_file_reader = LabelsFileReader(labels_file_path)
+                self._labels_file_reader.__enter__()
+
+            return self._labels_file_reader._json_stream[item_id]
+
+        try:
+            return _parse_item()
+        except json_stream.base.TransientAccessException:
+            # The items are accessed lazily in the reverse order
+            # or the stream is reiterated mid iteration
             self._labels_file_reader.close()
             self._labels_file_reader = None
-
-        if not self._labels_file_reader:
-            self._labels_file_reader = self.LabelsFileReader(labels_file_path)
-            self._labels_file_reader.__enter__()
-
-        return self._labels_file_reader.json_stream[item_id]
+            return _parse_item()
 
     def _parse_annotations(self, image: Image, *, item_id: Tuple[str, str]) -> List[Annotation]:
         item_id, subset_name = item_id
@@ -904,7 +923,7 @@ class YoloUltralyticsClassificationBase(_YoloBase):
         if not osp.isfile(labels_file_path):
             return labels
 
-        with self.LabelsFileReader(self._get_labels_file_path(subset_name)) as reader:
+        with LabelsFileReader(self._get_labels_file_path(subset_name)) as reader:
             for item_info in reader.values():
                 labels.update(item_info["labels"])
 

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -5,10 +5,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 import os
 import os.path as osp
 import re
+from collections.abc import Generator
 from functools import cached_property, partial
 from itertools import cycle
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
@@ -821,7 +821,7 @@ class YoloUltralyticsClassificationBase(_YoloBase):
                 self.file.close()
                 self.file = None
 
-    def __init__(self, rootpath, image_info = None, stream = False, **kwargs):
+    def __init__(self, rootpath, image_info=None, stream=False, **kwargs):
         self._labels_file_reader = None
         super().__init__(rootpath, image_info, stream, **kwargs)
 
@@ -832,7 +832,9 @@ class YoloUltralyticsClassificationBase(_YoloBase):
             if osp.isdir(osp.join(self._path, subset_name))
         ]
 
-    def _get_image_paths_for_subset_and_label(self, subset_name: str, label_name: str) -> Generator[list[str], None, None]:
+    def _get_image_paths_for_subset_and_label(
+        self, subset_name: str, label_name: str
+    ) -> Generator[list[str], None, None]:
         category_folder = osp.join(self._path, subset_name, label_name)
         image_list_path = osp.join(category_folder, YoloUltralyticsClassificationFormat.LABELS_FILE)
         if osp.isfile(image_list_path):

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -850,12 +850,6 @@ class YoloUltralyticsClassificationBase(_YoloBase):
         subset_path = osp.join(self._path, subset_name)
         return osp.join(subset_path, YoloUltralyticsClassificationFormat.LABELS_FILE)
 
-    def _get_items_from_labels_file(self, subset_name: str) -> Optional[Dict]:
-        labels_file_path = self._get_labels_file_path(subset_name)
-
-        if osp.isfile(labels_file_path):
-            return parse_json_file(labels_file_path)
-
     def _get_lazy_subset_items(self, subset_name: str):
         with self.LabelsFileReader(self._get_labels_file_path(subset_name)) as reader:
             return {

--- a/src/datumaro/plugins/data_formats/yolo/base.py
+++ b/src/datumaro/plugins/data_formats/yolo/base.py
@@ -790,6 +790,14 @@ class YoloUltralyticsPoseBase(YoloUltralyticsDetectionBase):
 
 
 class YoloUltralyticsClassificationBase(_YoloBase):
+    def __init__(self, rootpath, image_info=None, stream=False, **kwargs):
+        self._labels_file_cache: dict[str, dict] = {}
+        super().__init__(rootpath, image_info, stream, **kwargs)
+
+    def __iter__(self):
+        yield from super().__iter__()
+        self._labels_file_cache.clear()
+
     def _get_subset_names(self):
         return [
             subset_name
@@ -812,8 +820,17 @@ class YoloUltralyticsClassificationBase(_YoloBase):
     def _get_item_info_from_labels_file(self, subset_name: str) -> Optional[Dict]:
         subset_path = osp.join(self._path, subset_name)
         labels_file_path = osp.join(subset_path, YoloUltralyticsClassificationFormat.LABELS_FILE)
-        if osp.isfile(labels_file_path):
-            return parse_json_file(labels_file_path)
+
+        if labels_file_path in self._labels_file_cache:
+            parsed_data = self._labels_file_cache[labels_file_path]
+        else:
+            if osp.isfile(labels_file_path):
+                parsed_data = parse_json_file(labels_file_path)
+                self._labels_file_cache[labels_file_path] = parsed_data
+            else:
+                parsed_data = None
+
+        return parsed_data
 
     def _get_lazy_subset_items(self, subset_name: str):
         subset_path = osp.join(self._path, subset_name)

--- a/src/datumaro/plugins/data_formats/yolo/exporter.py
+++ b/src/datumaro/plugins/data_formats/yolo/exporter.py
@@ -535,11 +535,6 @@ class YoloUltralyticsClassificationExporter(Exporter):
             image_fpath = self._generate_path_for_item(item, label_folder_path)
 
             if self._save_media:
-                if not item.media or not (item.media.has_data or item.media.has_size):
-                    raise DatasetExportError(
-                        "Failed to export item '%s': " "item has no image info" % item.id
-                    )
-
                 if item.media:
                     os.makedirs(label_folder_path, exist_ok=True)
                     self._save_image(item, image_fpath)

--- a/src/datumaro/plugins/data_formats/yolo/exporter.py
+++ b/src/datumaro/plugins/data_formats/yolo/exporter.py
@@ -529,16 +529,17 @@ class YoloUltralyticsClassificationExporter(Exporter):
 
     def _export_media_for_label(self, item: DatasetItem, subset_name: str, label_name: str) -> str:
         try:
-            if not item.media or not (item.media.has_data or item.media.has_size):
-                raise DatasetExportError(
-                    "Failed to export item '%s': " "item has no image info" % item.id
-                )
             subset_path = osp.join(self._save_dir, subset_name)
             label_folder_path = osp.join(subset_path, label_name)
 
             image_fpath = self._generate_path_for_item(item, label_folder_path)
 
             if self._save_media:
+                if not item.media or not (item.media.has_data or item.media.has_size):
+                    raise DatasetExportError(
+                        "Failed to export item '%s': " "item has no image info" % item.id
+                    )
+
                 if item.media:
                     os.makedirs(label_folder_path, exist_ok=True)
                     self._save_image(item, image_fpath)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Related https://github.com/cvat-ai/cvat/issues/10141

Both in streaming and standard more, Ultralytics YOLO Classification importer reads and parses the labels JSON file for each `DatasetItem`. It works for small datasets, but results in poor performance for datasets > 20k images.

- Optimized reading performance
- Removed invalid media existence check in the exporter

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

```
import datumaro as dm

dataset = dm.Dataset.import_from(
    "ultralytics yolo classification_dataset/",
    format="yolo_ultralytics_classification"
)

dataset.init_cache()

for label_name in ["cat", "dog", "mouse"]:
    dataset.categories()[dm.AnnotationType.label].add(label_name)

label_count = 3

for i, sample in enumerate(dataset):
    sample.annotations.append(dm.Label(label=i % label_count))

dataset.export(
    "ultralytics yolo classification-updated/",
    format="yolo_ultralytics_classification",
    save_media=False
)
```

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
