### PR TITLE
Fix saving in the MOTS format with RleMask annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Invalid handling of Mac OS special dirs in format detection
   (<https://github.com/cvat-ai/datumaro/pull/88>)
 - ICDAR exporter does not require index attributes anymore
-- (<https://github.com/cvat-ai/datumaro/pull/105>)
+  (<https://github.com/cvat-ai/datumaro/pull/105>)
+- MOTS exporter now works with RLE masks when NumPy 2.x is used
+  (<https://github.com/cvat-ai/datumaro/pull/132>)
 
 ### Security
 - TBD

--- a/src/datumaro/plugins/data_formats/mots.py
+++ b/src/datumaro/plugins/data_formats/mots.py
@@ -183,6 +183,6 @@ class MotsPngExporter(Exporter):
         instance_ids = [int(a.attributes["track_id"]) for a in masks]
         masks = sorted(zip(masks, instance_ids), key=lambda e: e[0].z_order)
         mask = merge_masks(
-            (m.image, MotsPath.MAX_INSTANCES * (1 + m.label) + id) for m, id in masks
+            (m.image, np.uint16(MotsPath.MAX_INSTANCES * (1 + m.label) + id)) for m, id in masks
         )
         save_image(osp.join(anno_dir, item.id + ".png"), mask, create_dir=True, dtype=np.uint16)

--- a/tests/unit/test_mots_format.py
+++ b/tests/unit/test_mots_format.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 
 import numpy as np
 
-from datumaro.components.annotation import Mask
+import datumaro.util.mask_tools as mask_tools
+from datumaro.components.annotation import Mask, RleMask
 from datumaro.components.dataset import Dataset
 from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import Environment
@@ -225,6 +226,35 @@ class MotsPngExporterTest(TestCase):
                 require_media=True,
             )
             self.assertTrue(osp.isfile(osp.join(test_dir, "dataset_meta.json")))
+
+    @mark_requirement(Requirements.DATUM_GENERAL_REQ)
+    def test_can_save_and_load_rle_mask(self):
+        source_dataset = Dataset.from_iterable(
+            [
+                DatasetItem(
+                    id="1",
+                    subset="a",
+                    media=Image.from_numpy(data=np.ones((5, 1))),
+                    annotations=[
+                        RleMask(
+                            rle=mask_tools.to_uncompressed_rle(
+                                mask_tools.mask_to_rle(np.array([[1, 1, 0, 0, 0]])),
+                                width=5,
+                                height=1,
+                            ),
+                            label=0,
+                            attributes={"track_id": 1},
+                        ),
+                    ],
+                ),
+            ],
+            categories=["label_0"],
+        )
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(
+                source_dataset, partial(MotsPngExporter.convert, save_media=False), test_dir
+            )
 
 
 class MotsImporterTest(TestCase):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
`MotsPngExporter` passes `m.image` for each mask into `merge_masks`. `RleMask.image` returns an ndarray of dtype `np.uint8`. Because of the changes in NEP 50, in NumPy 2.x the following no longer works:

    >>> np.array([[0]], dtype=np.uint8) * 1000
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    OverflowError: Python integer 1000 out of bounds for uint8

A multiplication like this happens in `merge_masks`, which breaks `MotsPngExporter`.

Fix this by explicitly casting the mask color (the integer) to the expected type in the exporter.


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
