### PR TITLE
Fix compatibility with Pillow 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/105>)
 - MOTS exporter now works with RLE masks when NumPy 2.x is used
   (<https://github.com/cvat-ai/datumaro/pull/132>)
+- Cityscapes and KITTY exporters are now compatible with Pillow 13
+  (<https://github.com/cvat-ai/datumaro/pull/136>)
 
 ### Security
 - TBD

--- a/src/datumaro/plugins/data_formats/cityscapes.py
+++ b/src/datumaro/plugins/data_formats/cityscapes.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2023 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) 2022-2026 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -522,7 +522,7 @@ class CityscapesExporter(Exporter):
                     inst_mask_path,
                     compiled_mask.instance_mask,
                     apply_colormap=False,
-                    dtype=np.int32,
+                    dtype=np.uint16,
                 )
         self.save_label_map()
 

--- a/src/datumaro/plugins/data_formats/kitti/exporter.py
+++ b/src/datumaro/plugins/data_formats/kitti/exporter.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021 Intel Corporation
-# Copyright (C) 2022 CVAT.ai Corporation
+# Copyright (C) 2022-2026 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -149,7 +149,7 @@ class KittiExporter(Exporter):
                         osp.join(self._save_dir, labelids_mask_path),
                         compiled_class_mask.class_mask,
                         apply_colormap=False,
-                        dtype=np.int32,
+                        dtype=np.uint16,
                     )
 
                     # TODO: optimize second merging
@@ -167,7 +167,7 @@ class KittiExporter(Exporter):
                         osp.join(self._save_dir, inst_path),
                         compiled_instance_mask.class_mask,
                         apply_colormap=False,
-                        dtype=np.int32,
+                        dtype=np.uint16,
                     )
 
                 bboxes = [a for a in item.annotations if a.type == AnnotationType.bbox]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

Pillow allows you to save 32-bit tensors as PNG. However, PNG doesn't support 32-bit images, so doing this actually converts the data to 16-bit. Apparently Pillow 13 is going to stop supporting this implicit conversion, so we have to do it ourselves.

This is technically a change in behavior, because Pillow handles out-of-range values by clipping them to 0xffff, while Datumaro's `save_image` just chops off the high bits (via `ndarray.astype`). I don't think it really matters, though, since data is lost either way.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- ~~[ ] I have added unit tests to cover my changes.​~~
- ~~[ ] I have added integration tests to cover my changes.​~~
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- ~~[ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly~~

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
