### PR TITLE
Improve CLI import error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/datumaro/pull/41>)
 - Always use exif orientation info when loading images
   (<https://github.com/cvat-ai/datumaro/pull/82>)
+- \[CLI\] Import-based commands now show the underlying dataset import failure
+  (<https://github.com/cvat-ai/datumaro/issues/89>)
 
 ### Deprecated
 - `--save-images` is replaced with `--save-media` in CLI and converter API

--- a/src/datumaro/cli/util/errors.py
+++ b/src/datumaro/cli/util/errors.py
@@ -11,9 +11,36 @@ class CliException(DatumaroError):
     pass
 
 
+@attrs(frozen=True)
+class RevpathParseProblem:
+    description = attrib()
+    error = attrib()
+
+    def format(self, indent="  "):
+        lines = [f"{indent}{self.description}:"]
+        cause = self.error
+        seen = set()
+        cause_indent = indent * 2
+
+        while cause is not None and id(cause) not in seen:
+            seen.add(id(cause))
+            message = str(cause).strip()
+            details = type(cause).__name__
+            if message:
+                details += f": {message}"
+
+            prefix = "" if len(lines) == 1 else "Caused by: "
+            lines.append(f"{cause_indent}{prefix}{details}")
+            cause = cause.__cause__
+
+        return "\n".join(lines)
+
+
 @attrs
 class WrongRevpathError(CliException):
+    revpath = attrib()
     problems = attrib()
 
     def __str__(self):
-        return "Failed to parse revspec:\n  " + "\n  ".join(str(p) for p in self.problems)
+        details = "\n\n".join(problem.format() for problem in self.problems)
+        return f"Failed to parse revpath {self.revpath!r}:\n\n{details}"

--- a/src/datumaro/cli/util/project.py
+++ b/src/datumaro/cli/util/project.py
@@ -6,7 +6,7 @@ import os
 import re
 from typing import Optional, Tuple
 
-from datumaro.cli.util.errors import WrongRevpathError
+from datumaro.cli.util.errors import RevpathParseProblem, WrongRevpathError
 from datumaro.components.dataset import Dataset
 from datumaro.components.environment import DEFAULT_ENVIRONMENT, Environment
 from datumaro.components.errors import DatumaroError, ProjectNotFoundError
@@ -132,18 +132,18 @@ def parse_full_revpath(
     else:
         env = DEFAULT_ENVIRONMENT
 
-    errors = []
+    problems = []
     try:
         return parse_revspec(s, ctx_project=ctx_project)
     except (DatumaroError, OSError) as e:
-        errors.append(e)
+        problems.append(RevpathParseProblem("As a project revision", e))
 
     try:
         return parse_dataset_pathspec(s, env=env), None
     except (DatumaroError, OSError) as e:
-        errors.append(e)
+        problems.append(RevpathParseProblem("As a dataset path", e))
 
-    raise WrongRevpathError(problems=errors)
+    raise WrongRevpathError(revpath=s, problems=problems)
 
 
 def split_local_revpath(revpath: str) -> Tuple[Revision, str]:

--- a/tests/integration/cli/test_revpath.py
+++ b/tests/integration/cli/test_revpath.py
@@ -3,6 +3,7 @@ import os.path as osp
 import shutil
 from unittest.case import TestCase
 
+from datumaro.cli.util.errors import RevpathParseProblem
 from datumaro.cli.util.project import WrongRevpathError, parse_full_revpath, split_local_revpath
 from datumaro.components.dataset import DEFAULT_FORMAT, Dataset, IDataset
 from datumaro.components.dataset_base import DatasetItem
@@ -147,7 +148,12 @@ class TestRevpath(TestCase):
                 parse_full_revpath(dataset_url)
             self.assertEqual(
                 {ProjectNotFoundError, MultipleFormatsMatchError},
-                set(type(e) for e in cm.exception.problems),
+                {type(problem.error) for problem in cm.exception.problems},
+            )
+            self.assertEqual(dataset_url, cm.exception.revpath)
+            self.assertEqual(
+                ["As a project revision", "As a dataset path"],
+                [problem.description for problem in cm.exception.problems],
             )
 
         proj_dir = osp.join(test_dir, "proj")
@@ -158,8 +164,35 @@ class TestRevpath(TestCase):
                 parse_full_revpath(dataset_url, proj)
             self.assertEqual(
                 {UnknownTargetError, MultipleFormatsMatchError},
-                set(type(e) for e in cm.exception.problems),
+                {type(problem.error) for problem in cm.exception.problems},
             )
+
+    def test_wrong_revpath_error_reports_cause_chain(self):
+        root_error = ValueError("invalid annotation")
+        import_error = RuntimeError("failed to import dataset")
+        import_error.__cause__ = root_error
+
+        error = WrongRevpathError(
+            revpath="broken/path",
+            problems=[RevpathParseProblem("As a dataset path", import_error)],
+        )
+
+        self.assertEqual(
+            "Failed to parse revpath 'broken/path':\n"
+            "\n"
+            "  As a dataset path:\n"
+            "    RuntimeError: failed to import dataset\n"
+            "    Caused by: ValueError: invalid annotation",
+            str(error),
+        )
+
+    def test_wrong_revpath_error_handles_empty_messages(self):
+        error = WrongRevpathError(
+            revpath="broken/path",
+            problems=[RevpathParseProblem("As a dataset path", RuntimeError())],
+        )
+
+        self.assertIn("    RuntimeError", str(error))
 
     @mark_requirement(Requirements.DATUM_GENERAL_REQ)
     def test_can_split_local_revpath(self):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/cvat-ai/datumaro#contributing -->

### Summary

<!--
Resolves #89.

This PR improves the error reported when Datumaro cannot parse a revpath.

Previously, `WrongRevpathError` only displayed the top-level errors produced by the available parsing attempts. As a result, useful details stored in the exceptions' `__cause__` chains were hidden.

This PR:

- Added structured descriptions for each attempted revpath interpretation.
- Fixed the problem #89 


### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

python -m pytest -v tests/integration/cli/test_revpath.py

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added the description of my changes into [CHANGELOG](https://github.com/cvat-ai/datumaro/blob/develop/CHANGELOG.md).​
- [ ] I have updated the [documentation](https://github.com/cvat-ai/datumaro/tree/develop/docs) accordingly

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/datumaro/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 CVAT.ai Corporation
#
# SPDX-License-Identifier: MIT
```
